### PR TITLE
#258 Behavior tree - prioritize player commands

### DIFF
--- a/apps/client/src/app/probable-waffle/game/data/actor-data.ts
+++ b/apps/client/src/app/probable-waffle/game/data/actor-data.ts
@@ -27,6 +27,7 @@ import { getActorComponent } from "./actor-component";
 import { DepthHelper } from "../world/map/depth.helper";
 import GameObject = Phaser.GameObjects.GameObject;
 import Transform = Phaser.GameObjects.Components.Transform;
+import { ActionSystem } from "../entity/systems/action.system";
 
 export const ActorDataKey = "actorData";
 export class ActorData {
@@ -147,7 +148,10 @@ function gatherCompletedActorData(actor: Phaser.GameObjects.GameObject): { compo
   ];
 
   const systemDefinitions = definition.systems;
-  const systems = [...(systemDefinitions?.movement ? [new MovementSystem(actor)] : [])];
+  const systems = [
+    ...(systemDefinitions?.movement ? [new MovementSystem(actor)] : []),
+    ...(systemDefinitions?.action ? [new ActionSystem(actor)] : [])
+  ];
   return { components, systems };
 }
 

--- a/apps/client/src/app/probable-waffle/game/data/actor-data.ts
+++ b/apps/client/src/app/probable-waffle/game/data/actor-data.ts
@@ -28,6 +28,7 @@ import { DepthHelper } from "../world/map/depth.helper";
 import GameObject = Phaser.GameObjects.GameObject;
 import Transform = Phaser.GameObjects.Components.Transform;
 import { ActionSystem } from "../entity/systems/action.system";
+import { HealingComponent } from "../entity/combat/components/healing-component";
 
 export const ActorDataKey = "actorData";
 export class ActorData {
@@ -139,6 +140,7 @@ function gatherCompletedActorData(actor: Phaser.GameObjects.GameObject): { compo
       ? [new ResourceSourceComponent(actor, componentDefinitions.resourceSource)]
       : []),
     ...(componentDefinitions?.production ? [new ProductionComponent(actor, componentDefinitions.production)] : []),
+    ...(componentDefinitions?.healing ? [new HealingComponent(actor, componentDefinitions.healing)] : []),
     ...(componentDefinitions?.builder ? [new BuilderComponent(actor, componentDefinitions.builder)] : []),
     ...(componentDefinitions?.gatherer ? [new GathererComponent(actor, componentDefinitions.gatherer)] : []),
     ...(componentDefinitions?.translatable

--- a/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
+++ b/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
@@ -136,7 +136,8 @@ const tivaraWorkerDefinition: ActorInfoDefinition = {
     }
   },
   systems: {
-    movement: { enabled: true }
+    movement: { enabled: true },
+    action: { enabled: true }
   }
 };
 
@@ -213,7 +214,8 @@ const skaduweeWorkerDefinition: ActorInfoDefinition = {
     }
   },
   systems: {
-    movement: { enabled: true }
+    movement: { enabled: true },
+    action: { enabled: true }
   }
 };
 
@@ -242,6 +244,9 @@ export type ActorInfoDefinition = Partial<{
   }>;
   systems: Partial<{
     movement: {
+      enabled: boolean;
+    };
+    action: {
       enabled: boolean;
     };
   }>;
@@ -395,7 +400,8 @@ export const pwActorDefinitions: {
       }
     },
     systems: {
-      movement: { enabled: true }
+      movement: { enabled: true },
+      action: { enabled: true }
     }
   },
   [ObjectNames.TivaraSlingshotFemale]: {
@@ -458,7 +464,8 @@ export const pwActorDefinitions: {
       }
     },
     systems: {
-      movement: { enabled: true }
+      movement: { enabled: true },
+      action: { enabled: true }
     }
   },
   [ObjectNames.TivaraWorkerFemale]: {
@@ -812,7 +819,10 @@ export const pwActorDefinitions: {
         tileStepDuration: 1000
       }
     },
-    systems: { movement: { enabled: true } }
+    systems: {
+      movement: { enabled: true },
+      action: { enabled: true }
+    }
   },
   [ObjectNames.SkaduweeRangedFemale]: {
     components: {
@@ -874,7 +884,8 @@ export const pwActorDefinitions: {
       }
     },
     systems: {
-      movement: { enabled: true }
+      movement: { enabled: true },
+      action: { enabled: true }
     }
   },
   [ObjectNames.SkaduweeMagicianFemale]: {
@@ -936,7 +947,8 @@ export const pwActorDefinitions: {
       }
     },
     systems: {
-      movement: { enabled: true }
+      movement: { enabled: true },
+      action: { enabled: true }
     }
   },
   [ObjectNames.SkaduweeWarriorMale]: {
@@ -999,7 +1011,8 @@ export const pwActorDefinitions: {
       }
     },
     systems: {
-      movement: { enabled: true }
+      movement: { enabled: true },
+      action: { enabled: true }
     }
   },
   [ObjectNames.SkaduweeWorkerMale]: {

--- a/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
+++ b/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
@@ -36,11 +36,11 @@ import { ConstructionSiteDefinition } from "../entity/building/construction/cons
 const coreConstructionSiteDefinition: ConstructionSiteDefinition = {
   consumesBuilders: false,
   maxAssignedBuilders: 4,
-  progressMadeAutomatically: 1,
+  progressMadeAutomatically: 0,
   progressMadePerBuilder: 1,
   initialHealthPercentage: 0.2,
   refundFactor: 0.5,
-  startImmediately: true,
+  startImmediately: false,
   canBeDragPlaced: false
 };
 

--- a/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
+++ b/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
@@ -36,9 +36,11 @@ import { ConstructionSiteDefinition } from "../entity/building/construction/cons
 const coreConstructionSiteDefinition: ConstructionSiteDefinition = {
   consumesBuilders: false,
   maxAssignedBuilders: 4,
+  maxAssignedRepairers: 2,
   progressMadeAutomatically: 0,
   progressMadePerBuilder: 1,
   initialHealthPercentage: 0.2,
+  repairFactor: 0.005,
   refundFactor: 0.5,
   startImmediately: false,
   canBeDragPlaced: false

--- a/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
+++ b/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
@@ -32,6 +32,7 @@ import { ResourceSourceDefinition } from "../entity/economy/resource/resource-so
 import { ActorTranslateDefinition } from "../entity/actor/components/actor-translate-component";
 import { AiType, PawnAiDefinition } from "../world/managers/controllers/player-pawn-ai-controller/pawn-ai-controller";
 import { ConstructionSiteDefinition } from "../entity/building/construction/construction-site-component";
+import { HealingDefinition } from "../entity/combat/components/healing-component";
 
 const coreConstructionSiteDefinition: ConstructionSiteDefinition = {
   consumesBuilders: false,
@@ -64,8 +65,66 @@ const treeDefinitions: ActorInfoDefinition = {
   }
 };
 
-const tivaraWorkerDefinition: ActorInfoDefinition = {
+const generalWorkerDefinitions: Partial<ActorInfoDefinition> = {
   components: {
+    vision: {
+      range: 5
+    },
+    health: {
+      maxHealth: 100
+    },
+    attack: {
+      attacks: [
+        {
+          damage: 1,
+          damageType: DamageType.Physical,
+          cooldown: 1000,
+          range: 1
+        }
+      ]
+    },
+    productionCost: {
+      resources: {
+        [ResourceType.Wood]: 10,
+        [ResourceType.Minerals]: 10
+      },
+      refundFactor: 0.5,
+      productionTime: 5000,
+      costType: PaymentType.PayImmediately
+    },
+    healing: {
+      range: 2,
+      healPerCooldown: 5,
+      cooldown: 1000
+    },
+    gatherer: {
+      resourceSweepRadius: 20,
+      resourceSourceGameObjectClasses: [
+        ResourceType.Ambrosia,
+        ResourceType.Wood,
+        ResourceType.Minerals,
+        ResourceType.Stone
+      ]
+    },
+    selectable: { enabled: true },
+    translatable: {
+      tileStepDuration: 500
+    },
+    containable: { enabled: true },
+    aiControlled: {
+      type: AiType.Character
+    }
+  },
+  systems: {
+    movement: { enabled: true },
+    action: { enabled: true }
+  }
+};
+
+const tivaraWorkerDefinition: ActorInfoDefinition = {
+  ...generalWorkerDefinitions,
+  components: {
+    ...generalWorkerDefinitions.components,
     objectDescriptor: {
       color: 0xc2a080
     },
@@ -77,35 +136,12 @@ const tivaraWorkerDefinition: ActorInfoDefinition = {
         }
       ]
     },
-    vision: {
-      range: 5
-    },
-    health: {
-      maxHealth: 100
-    },
-    attack: {
-      attacks: [
-        {
-          damage: 1,
-          damageType: DamageType.Physical,
-          cooldown: 1000,
-          range: 1
-        }
-      ]
-    },
-    productionCost: {
-      resources: {
-        [ResourceType.Wood]: 10,
-        [ResourceType.Minerals]: 10
-      },
-      refundFactor: 0.5,
-      productionTime: 5000,
-      costType: PaymentType.PayImmediately
-    },
     requirements: {
       actors: [ObjectNames.Sandhold]
     },
     builder: {
+      constructionSiteOffset: 2,
+      enterConstructionSite: false,
       constructableBuildings: [
         ObjectNames.Sandhold,
         ObjectNames.AnkGuard,
@@ -115,36 +151,15 @@ const tivaraWorkerDefinition: ActorInfoDefinition = {
         ObjectNames.WatchTower,
         ObjectNames.Wall,
         ObjectNames.Stairs
-      ],
-      constructionSiteOffset: 2,
-      enterConstructionSite: false
-    },
-    gatherer: {
-      resourceSweepRadius: 20,
-      resourceSourceGameObjectClasses: [
-        ResourceType.Ambrosia,
-        ResourceType.Wood,
-        ResourceType.Minerals,
-        ResourceType.Stone
       ]
-    },
-    selectable: { enabled: true },
-    translatable: {
-      tileStepDuration: 500
-    },
-    containable: { enabled: true },
-    aiControlled: {
-      type: AiType.Character
     }
-  },
-  systems: {
-    movement: { enabled: true },
-    action: { enabled: true }
   }
 };
 
 const skaduweeWorkerDefinition: ActorInfoDefinition = {
+  ...generalWorkerDefinitions,
   components: {
+    ...generalWorkerDefinitions.components,
     objectDescriptor: {
       color: 0xf2f7fa
     },
@@ -156,35 +171,12 @@ const skaduweeWorkerDefinition: ActorInfoDefinition = {
         }
       ]
     },
-    vision: {
-      range: 5
-    },
-    health: {
-      maxHealth: 100
-    },
-    attack: {
-      attacks: [
-        {
-          damage: 1,
-          damageType: DamageType.Physical,
-          cooldown: 1000,
-          range: 1
-        }
-      ]
-    },
-    productionCost: {
-      resources: {
-        [ResourceType.Wood]: 10,
-        [ResourceType.Minerals]: 10
-      },
-      refundFactor: 0.5,
-      productionTime: 5000,
-      costType: PaymentType.PayImmediately
-    },
     requirements: {
       actors: [ObjectNames.FrostForge]
     },
     builder: {
+      constructionSiteOffset: 2,
+      enterConstructionSite: false,
       constructableBuildings: [
         ObjectNames.FrostForge,
         ObjectNames.InfantryInn,
@@ -193,34 +185,10 @@ const skaduweeWorkerDefinition: ActorInfoDefinition = {
         ObjectNames.WatchTower,
         ObjectNames.Wall,
         ObjectNames.Stairs
-      ],
-      constructionSiteOffset: 2,
-      enterConstructionSite: false
-    },
-    gatherer: {
-      resourceSweepRadius: 20,
-      resourceSourceGameObjectClasses: [
-        ResourceType.Ambrosia,
-        ResourceType.Wood,
-        ResourceType.Minerals,
-        ResourceType.Stone
       ]
-    },
-    selectable: { enabled: true },
-    translatable: {
-      tileStepDuration: 500
-    },
-    containable: { enabled: true },
-    aiControlled: {
-      type: AiType.Character
     }
-  },
-  systems: {
-    movement: { enabled: true },
-    action: { enabled: true }
   }
 };
-
 export type ActorInfoDefinition = Partial<{
   components: Partial<{
     objectDescriptor: ObjectDescriptorDefinition;
@@ -238,6 +206,7 @@ export type ActorInfoDefinition = Partial<{
     resourceDrain: ResourceDrainDefinition;
     resourceSource: ResourceSourceDefinition;
     production: ProductionDefinition;
+    healing: HealingDefinition;
     translatable: ActorTranslateDefinition;
     aiControlled: PawnAiDefinition;
     containable: { enabled: boolean };

--- a/apps/client/src/app/probable-waffle/game/data/game-object-helper.ts
+++ b/apps/client/src/app/probable-waffle/game/data/game-object-helper.ts
@@ -2,6 +2,10 @@ import { getSceneInitializers, getSceneService } from "../scenes/components/scen
 import { NavigationService } from "../scenes/services/navigation.service";
 import { Vector2Simple } from "@fuzzy-waddle/api-interfaces";
 import { filter, first } from "rxjs";
+import { GameObjects } from "phaser";
+import { SelectableComponent } from "../entity/actor/components/selectable-component";
+import { IdComponent } from "../entity/actor/components/id-component";
+import { getActorComponent } from "./actor-component";
 
 export function getGameObjectBounds(gameObject?: Phaser.GameObjects.GameObject): Phaser.Geom.Rectangle | null {
   if (!gameObject) return null;
@@ -64,6 +68,17 @@ export function getGameObjectCurrentTile(gameObject: Phaser.GameObjects.GameObje
   if (!navigationService) return;
 
   return navigationService.getCenterTileCoordUnderObject(gameObject);
+}
+
+export function getSelectableGameObject(
+  go: GameObjects.GameObject
+): (GameObjects.GameObject & { selectableComponent: SelectableComponent; idComponent: IdComponent }) | null {
+  const hasComp = !!getActorComponent(go, SelectableComponent) && !!getActorComponent(go, IdComponent);
+  if (hasComp) return go as any;
+
+  const parent = go.parentContainer;
+  if (!parent) return null;
+  return getSelectableGameObject(parent);
 }
 
 /**

--- a/apps/client/src/app/probable-waffle/game/data/scene-data.ts
+++ b/apps/client/src/app/probable-waffle/game/data/scene-data.ts
@@ -173,6 +173,21 @@ export function emitEventIssueMoveCommandToSelectedActors(
   });
 }
 
+export function emitEventIssueActorCommandToSelectedActors(scene: Phaser.Scene, objectIds: string[]) {
+  if (!(scene instanceof ProbableWaffleScene)) throw new Error("Scene is not of type ProbableWaffleScene");
+  scene.communicator.playerChanged!.send({
+    property: "command.issued.actor",
+    data: {
+      playerNumber: getPlayer(scene)?.playerNumber,
+      data: {
+        objectIds
+      }
+    },
+    gameInstanceId: scene.gameInstanceId,
+    emitterUserId: scene.userId
+  });
+}
+
 export function getSelectedActors(scene: Phaser.Scene): Phaser.GameObjects.GameObject[] {
   if (!(scene instanceof GameProbableWaffleScene)) throw new Error("Scene is not of type GameProbableWaffleScene");
   const selectionGuids = getPlayer(scene)?.getSelection();

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/builder-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/builder-component.ts
@@ -1,15 +1,10 @@
 import { ConstructionSiteComponent } from "../../building/construction/construction-site-component";
 import { ContainerComponent } from "../../building/container-component";
 import { Subject } from "rxjs";
-import { PawnAiControllerComponentOld } from "../../../world/managers/controllers/pawn-ai-controller-component-old";
-import { GameplayLibrary } from "../../../library/gameplay-library";
 import { getActorComponent } from "../../../data/actor-component";
-import { OwnerComponent } from "./owner-component";
-import { Vector3Simple } from "@fuzzy-waddle/api-interfaces";
 import { ObjectNames } from "../../../data/object-names";
-import GameObject = Phaser.GameObjects.GameObject;
 import { HealthComponent } from "../../combat/components/health-component";
-import { EventEmitter } from "@angular/core";
+import GameObject = Phaser.GameObjects.GameObject;
 
 export type BuilderDefinition = {
   // types of building the gameObject can produce
@@ -26,7 +21,7 @@ export class BuilderComponent {
   assignedConstructionSite?: GameObject;
 
   // when cooldown has expired
-  onCooldownReady: EventEmitter<GameObject> = new EventEmitter<GameObject>();
+  // onCooldownReady: EventEmitter<GameObject> = new EventEmitter<GameObject>();
   onConstructionSiteEntered: Subject<[GameObject, GameObject]> = new Subject<[GameObject, GameObject]>();
   onAssignedToConstructionSite: Subject<[GameObject, GameObject]> = new Subject<[GameObject, GameObject]>();
   onConstructionStarted: Subject<[GameObject, GameObject]> = new Subject<[GameObject, GameObject]>();
@@ -43,14 +38,15 @@ export class BuilderComponent {
     gameObject.once(HealthComponent.KilledEvent, this.destroy, this);
   }
 
-  private update(time: number, delta: number): void {
+  private update(_: number, delta: number): void {
     if (this.remainingCooldown <= 0) {
       return;
     }
     this.remainingCooldown -= delta;
-    if (this.remainingCooldown <= 0) {
-      this.onCooldownReady.emit(this.gameObject);
-    }
+    this.remainingCooldown = Math.max(this.remainingCooldown, 0);
+    // if (this.remainingCooldown <= 0) {
+    //   this.onCooldownReady.emit(this.gameObject);
+    // }
   }
 
   get constructableBuildings(): ObjectNames[] {
@@ -85,45 +81,6 @@ export class BuilderComponent {
     }
   }
 
-  beginConstruction(buildingClass: string, targetLocation: Vector3Simple): boolean {
-    const pawnAiController = getActorComponent(this.gameObject, PawnAiControllerComponentOld);
-    if (!pawnAiController) return false;
-    // check requirements
-    const missingRequirement = GameplayLibrary.getMissingRequirementsFor(this.gameObject, buildingClass);
-    if (missingRequirement) {
-      console.log("missing requirement", missingRequirement);
-      // player is missing a required gameObject. stop
-
-      pawnAiController.issueStopOrder();
-      return false;
-    }
-
-    // move builder away to avoid collision
-    // todo
-
-    // spawn building
-    const ownerComponent = getActorComponent(this.gameObject, OwnerComponent);
-    const scene = this.gameObject.scene;
-    // todo const building = gameMode.spawnGameObjectForPlayer(
-    // todo   scene,
-    // todo   buildingClass,
-    // todo   targetLocation,
-    // todo   ownerComponent.playerController
-    // todo );
-    const building = null;
-
-    if (!building) {
-      console.log("building could not be spawned");
-      return false;
-    }
-
-    this.onConstructionStarted.next([this.gameObject, building]);
-
-    // issue building order
-    // pawnAiController.issueContinueConstructionOrder(building);
-    return true;
-  }
-
   leaveConstructionSite() {
     if (!this.assignedConstructionSite) return;
 
@@ -149,10 +106,60 @@ export class BuilderComponent {
     }
   }
 
-  getConstructionRange(buildingType: string | undefined): number {
-    // return collision radius of building
-    // todo return URTSCollisionLibrary::GetCollisionSize(ConstructibleBuildingClasses[Index]) / 2;
-    return 1; // todo
+  getConstructionRange(): number {
+    return 1;
+  }
+
+  getRepairRange() {
+    return 1;
+  }
+
+  assignToRepairSite(target: Phaser.GameObjects.GameObject) {
+    if (this.assignedConstructionSite === target) return;
+
+    const constructionSiteComponent = getActorComponent(target, ConstructionSiteComponent);
+    if (!constructionSiteComponent) return;
+
+    if (!constructionSiteComponent.canAssignRepairer()) {
+      // todo play sound and show notification on screen - same as "the production queue is full"
+      return;
+    }
+    this.assignedConstructionSite = target;
+    constructionSiteComponent.assignRepairer(this.gameObject);
+    this.onAssignedToConstructionSite.next([this.gameObject, target]);
+
+    if (this.builderComponentDefinition.enterConstructionSite) {
+      const containerComponent = getActorComponent(target, ContainerComponent);
+      if (containerComponent) {
+        containerComponent.loadGameObject(this.gameObject);
+        this.onConstructionSiteEntered.next([this.gameObject, target]);
+      }
+    }
+  }
+
+  leaveRepairSite() {
+    if (!this.assignedConstructionSite) return;
+
+    const constructionSite = this.assignedConstructionSite;
+    const constructionSiteComponent = getActorComponent(constructionSite, ConstructionSiteComponent);
+    if (!constructionSiteComponent) return;
+
+    // remove repairer
+    this.assignedConstructionSite = undefined;
+    constructionSiteComponent.unAssignRepairer(this.gameObject);
+
+    // notify listeners
+    this.onRemovedFromConstructionSite.next([this.gameObject, constructionSite]);
+
+    console.log("builder left repair site");
+    if (this.builderComponentDefinition.enterConstructionSite) {
+      // leave repair site
+      const containerComponent = getActorComponent(constructionSite, ContainerComponent);
+      if (containerComponent) {
+        containerComponent.unloadGameObject(this.gameObject);
+        this.onConstructionSiteLeft.next([this.gameObject, constructionSite]);
+      }
+    }
   }
 
   private destroy() {

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/builder-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/builder-component.ts
@@ -101,7 +101,7 @@ export class BuilderComponent {
     this.onConstructionStarted.next([this.gameObject, building]);
 
     // issue building order
-    pawnAiController.issueContinueConstructionOrder(building);
+    // pawnAiController.issueContinueConstructionOrder(building);
     return true;
   }
 

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/gatherer-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/gatherer-component.ts
@@ -23,7 +23,7 @@ export type GathererDefinition = {
 export class GathererComponent {
   private static readonly debug = false;
   // when cooldown has expired
-  onCooldownReady: EventEmitter<GameObject> = new EventEmitter<GameObject>();
+  // onCooldownReady: EventEmitter<GameObject> = new EventEmitter<GameObject>();
   private readonly gatheredResources: GatherData[] = [
     {
       capacity: 3,
@@ -80,14 +80,15 @@ export class GathererComponent {
     gameObject.once(HealthComponent.KilledEvent, this.destroy, this);
   }
 
-  private update(time: number, delta: number): void {
+  private update(_: number, delta: number): void {
     if (this.remainingCooldown <= 0) {
       return;
     }
     this.remainingCooldown -= delta;
-    if (this.remainingCooldown <= 0) {
-      this.onCooldownReady.emit(this.gameObject);
-    }
+    this.remainingCooldown = Math.max(this.remainingCooldown, 0);
+    // if (this.remainingCooldown <= 0) {
+    //   this.onCooldownReady.emit(this.gameObject);
+    // }
   }
 
   private destroy() {

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/gatherer-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/gatherer-component.ts
@@ -142,7 +142,8 @@ export class GathererComponent {
 
   findClosestResourceDrain(): GameObject | null {
     if (this.carriedResourceType === null) {
-      throw new Error("Gatherer is not carrying any resources");
+      // Gatherer is not carrying any resources
+      return null;
     }
 
     // find nearby gameObjects
@@ -245,7 +246,8 @@ export class GathererComponent {
   async gatherResources(resourceSource: GameObject): Promise<number> {
     if (this.remainingCooldown > 0) return 0;
     if (!this.carriedResourceType) {
-      throw new Error("Gatherer is not carrying any resources");
+      // Gatherer is not carrying any resources
+      return 0;
     }
 
     // check resource type
@@ -310,7 +312,8 @@ export class GathererComponent {
 
   async returnResources(resourceDrain: GameObject): Promise<number> {
     if (!this.carriedResourceType) {
-      throw new Error("Gatherer is not carrying any resources");
+      // Gatherer is not carrying any resources
+      return 0;
     }
     // return resources
     const resourceDrainComponent = getActorComponent(resourceDrain, ResourceDrainComponent);

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/vision-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/vision-component.ts
@@ -45,7 +45,7 @@ export class VisionComponent {
       if (isSameTeam) return false; // Same team
 
       const healthComponent = getActorComponent(c, HealthComponent);
-      if (!healthComponent || healthComponent.healthComponentData.health <= 0) return false; // Dead or no health
+      if (!healthComponent || healthComponent.killed) return false; // Dead or no health
 
       const actorVisible = this.isActorVisible(c as GameObject);
       if (!actorVisible) return false; // Not visible

--- a/apps/client/src/app/probable-waffle/game/entity/building/construction/construction-site-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/building/construction/construction-site-component.ts
@@ -12,15 +12,18 @@ import { BehaviorSubject, Subject } from "rxjs";
 import { upgradeFromConstructingToFullActorData } from "../../../data/actor-data";
 import { ConstructionProgressUiComponent } from "./construction-progress-ui-component";
 import GameObject = Phaser.GameObjects.GameObject;
+import { BuilderComponent } from "../../actor/components/builder-component";
 
 export type ConstructionSiteDefinition = {
   // Whether the building site consumes builders when building is finished
   consumesBuilders: boolean;
   maxAssignedBuilders: number;
+  maxAssignedRepairers: number;
   // Factor to multiply all passed building time with, independent of any currently assigned builders
   progressMadeAutomatically: number;
   // Factor to multiply all passed building time with, dependent on the number of builders assigned
   progressMadePerBuilder: number;
+  repairFactor: number;
   initialHealthPercentage: number;
   refundFactor: number;
   // Whether to start building immediately after spawn, or not
@@ -43,6 +46,7 @@ export class ConstructionSiteComponent {
   } satisfies ConstructionSiteComponentData;
   public constructionStateChanged: Subject<ConstructionStateEnum> = new Subject<ConstructionStateEnum>();
   private assignedBuilders: GameObject[] = [];
+  private assignedRepairers: GameObject[] = [];
   constructionProgressUiComponent: ConstructionProgressUiComponent = new ConstructionProgressUiComponent(
     this.gameObject
   );
@@ -73,9 +77,14 @@ export class ConstructionSiteComponent {
 
   update(time: number, delta: number): void {
     if (this.constructionSiteData.state == ConstructionStateEnum.Finished) {
-      this.gameObject.scene.events.off(Phaser.Scenes.Events.UPDATE, this.update, this);
+      this.tryRepair(delta);
       return;
     }
+
+    this.tryBuild(delta);
+  }
+
+  private tryBuild(delta: number) {
     if (
       this.constructionSiteData.state === ConstructionStateEnum.NotStarted &&
       this.constructionSiteDefinition.startImmediately
@@ -208,7 +217,7 @@ export class ConstructionSiteComponent {
   }
 
   canAssignBuilder() {
-    return this.assignedBuilders.length < this.constructionSiteDefinition.maxAssignedBuilders;
+    return this.assignedBuilders.length < this.constructionSiteDefinition.maxAssignedBuilders && !this.isFinished();
   }
 
   assignBuilder(gameObject: GameObject) {
@@ -219,6 +228,47 @@ export class ConstructionSiteComponent {
     const index = this.assignedBuilders.indexOf(gameObject);
     if (index >= 0) {
       this.assignedBuilders.splice(index, 1);
+    }
+  }
+
+  canAssignRepairer() {
+    const healthComponent = getActorComponent(this.gameObject, HealthComponent);
+    if (!healthComponent) return false;
+    return (
+      this.assignedRepairers.length < this.constructionSiteDefinition.maxAssignedRepairers &&
+      healthComponent.healthComponentData.health < healthComponent.healthDefinition.maxHealth
+    );
+  }
+  assignRepairer(gameObject: GameObject) {
+    this.assignedRepairers.push(gameObject);
+  }
+  unAssignRepairer(gameObject: GameObject) {
+    const index = this.assignedRepairers.indexOf(gameObject);
+    if (index >= 0) {
+      this.assignedRepairers.splice(index, 1);
+    }
+  }
+
+  private tryRepair(delta: number) {
+    const healthComponent = getActorComponent(this.gameObject, HealthComponent);
+    if (!healthComponent) return;
+
+    if (this.assignedRepairers.length === 0) return;
+
+    const repairAmount = delta * this.constructionSiteDefinition.repairFactor * this.assignedRepairers.length;
+    healthComponent.healthComponentData.health += repairAmount;
+    healthComponent.healthComponentData.health = Math.min(
+      healthComponent.healthComponentData.health,
+      healthComponent.healthDefinition.maxHealth
+    );
+
+    if (healthComponent.healthComponentData.health >= healthComponent.healthDefinition.maxHealth) {
+      this.assignedRepairers.forEach((repairer) => {
+        const builderComponent = getActorComponent(repairer, BuilderComponent);
+        if (builderComponent) {
+          builderComponent.leaveRepairSite();
+        }
+      });
     }
   }
 

--- a/apps/client/src/app/probable-waffle/game/entity/building/construction/construction-site-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/building/construction/construction-site-component.ts
@@ -185,14 +185,6 @@ export class ConstructionSiteComponent {
       return;
     }
 
-    // refund resources
-
-    const ownerComponent = getActorComponent(this.gameObject, OwnerComponent);
-    const owner = ownerComponent?.getOwner();
-    if (!owner) throw new Error("Owner not found");
-    const player = getPlayer(this.gameObject.scene, owner);
-    if (!player) throw new Error("PlayerController not found");
-
     const productionDefinition = this.productionDefinition;
     if (!productionDefinition) throw new Error("Production definition not found");
 
@@ -209,7 +201,7 @@ export class ConstructionSiteComponent {
     emitResource(this.gameObject.scene, "resource.added", refundCosts);
 
     // destroy building
-    this.gameObject.destroy();
+    // this.gameObject.destroy();
   }
 
   isFinished() {

--- a/apps/client/src/app/probable-waffle/game/entity/building/construction/construction-site-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/building/construction/construction-site-component.ts
@@ -84,6 +84,10 @@ export class ConstructionSiteComponent {
       this.setInitialHealth();
     }
 
+    if (this.constructionSiteData.state === ConstructionStateEnum.NotStarted && this.assignedBuilders.length > 0) {
+      this.startConstruction();
+    }
+
     if (this.constructionSiteData.state !== ConstructionStateEnum.Constructing) return;
 
     const speedBoost = 1.0;

--- a/apps/client/src/app/probable-waffle/game/entity/character/ai/OrderData.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/character/ai/OrderData.ts
@@ -8,6 +8,6 @@ export class OrderData {
     public data: {
       targetGameObject?: GameObject;
       targetLocation?: Vector3Simple;
-    }
+    } = {}
   ) {}
 }

--- a/apps/client/src/app/probable-waffle/game/entity/character/ai/OrderData.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/character/ai/OrderData.ts
@@ -5,8 +5,9 @@ import GameObject = Phaser.GameObjects.GameObject;
 export class OrderData {
   constructor(
     public orderType: OrderType,
-    public targetGameObject?: GameObject,
-    public targetLocation?: Vector3Simple,
-    public args?: any[]
+    public data: {
+      targetGameObject?: GameObject;
+      targetLocation?: Vector3Simple;
+    }
   ) {}
 }

--- a/apps/client/src/app/probable-waffle/game/entity/character/ai/behavior/tasks/begin-construction.task.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/character/ai/behavior/tasks/begin-construction.task.ts
@@ -27,7 +27,7 @@ export class BeginConstructionTask implements ITask {
       return TaskResultType.Failure;
     }
 
-    builderComponent.beginConstruction(buildingType, targetLocation);
+    // builderComponent.beginConstruction(buildingType, targetLocation);
     return TaskResultType.Success;
   }
 }

--- a/apps/client/src/app/probable-waffle/game/entity/character/ai/default-pawn-behavior-tree_old.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/character/ai/default-pawn-behavior-tree_old.ts
@@ -1,18 +1,11 @@
 import { BehaviorTree } from "./behavior-tree";
-import { DecoratorData_old } from "./behavior/decorators/decorator.interface";
-import { TaskData_old } from "./behavior/tasks/task.interface";
 
 export class DefaultPawnBehaviorTree_old extends BehaviorTree {
   name: string;
-  private decoratorData: DecoratorData_old;
-  private taskData: TaskData_old;
 
   constructor() {
     super();
     this.name = "DefaultPawnBehaviorTree";
-
-    this.decoratorData = new DecoratorData_old(this.owner, this.blackboard);
-    this.taskData = new TaskData_old(this.owner, this.blackboard);
   }
 
   protected runDecisionTree(): void {

--- a/apps/client/src/app/probable-waffle/game/entity/character/ai/order-data_old.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/character/ai/order-data_old.ts
@@ -1,0 +1,12 @@
+import { OrderType } from "./order-type";
+import { Vector3Simple } from "@fuzzy-waddle/api-interfaces";
+import GameObject = Phaser.GameObjects.GameObject;
+
+export class OrderData_old {
+  constructor(
+    public orderType: OrderType,
+    public targetGameObject?: GameObject,
+    public targetLocation?: Vector3Simple,
+    public args?: any[]
+  ) {}
+}

--- a/apps/client/src/app/probable-waffle/game/entity/character/ai/order-type.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/character/ai/order-type.ts
@@ -12,7 +12,7 @@ export enum OrderType {
 
 export const OrderLabelToTypeMap: Record<string, OrderType> = {
   attack: OrderType.Attack,
-  beginConstruction: OrderType.Build,
+  build: OrderType.Build,
   gather: OrderType.Gather,
   move: OrderType.Move,
   returnResources: OrderType.ReturnResources,

--- a/apps/client/src/app/probable-waffle/game/entity/character/ai/order-type.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/character/ai/order-type.ts
@@ -1,19 +1,23 @@
 export enum OrderType {
-  Attack = 0,
-  BeginConstruction = 1,
-  ContinueConstruction = 2,
-  Gather = 3,
-  Move = 4,
-  ReturnResources = 5,
-  Stop = 6
+  Attack = "Attack",
+  Build = "Build",
+  Gather = "Gather",
+  Move = "Move",
+  ReturnResources = "ReturnResources",
+  Stop = "Stop",
+  Repair = "Repair",
+  Heal = "Heal",
+  EnterContainer = "EnterContainer"
 }
 
 export const OrderLabelToTypeMap: Record<string, OrderType> = {
   attack: OrderType.Attack,
-  beginConstruction: OrderType.BeginConstruction,
-  continueConstruction: OrderType.ContinueConstruction,
+  beginConstruction: OrderType.Build,
   gather: OrderType.Gather,
   move: OrderType.Move,
   returnResources: OrderType.ReturnResources,
-  stop: OrderType.Stop
+  stop: OrderType.Stop,
+  repair: OrderType.Repair,
+  heal: OrderType.Heal,
+  enterContainer: OrderType.EnterContainer
 };

--- a/apps/client/src/app/probable-waffle/game/entity/character/ai/pawn-ai-blackboard.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/character/ai/pawn-ai-blackboard.ts
@@ -7,6 +7,7 @@ export class PawnAiBlackboard extends Blackboard {
   private memory: Map<string, any> = new Map();
   private status: "idle" | "executing" | "paused" = "idle";
   private failedOrders: OrderData[] = [];
+  cancellationHandler?: () => void;
 
   getStatus(): string {
     return this.status;
@@ -51,7 +52,14 @@ export class PawnAiBlackboard extends Blackboard {
     this.status = "idle";
   }
 
+  overrideOrderQueueAndActiveOrder(orderData: OrderData): void {
+    this.orderQueue = [orderData];
+    this.resetCurrentOrder();
+    this.status = "idle";
+  }
+
   resetCurrentOrder(): void {
+    this.cancellationHandler?.();
     this.currentOrder = undefined;
   }
 

--- a/apps/client/src/app/probable-waffle/game/entity/character/ai/pawn-ai-blackboard.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/character/ai/pawn-ai-blackboard.ts
@@ -58,8 +58,10 @@ export class PawnAiBlackboard extends Blackboard {
     this.status = "idle";
   }
 
-  resetCurrentOrder(): void {
-    this.cancellationHandler?.();
+  resetCurrentOrder(callCancellationHandler: boolean = true): void {
+    if (callCancellationHandler) {
+      this.cancellationHandler?.();
+    }
     this.currentOrder = undefined;
   }
 
@@ -81,5 +83,9 @@ export class PawnAiBlackboard extends Blackboard {
 
   getFailedOrders(): OrderData[] {
     return [...this.failedOrders];
+  }
+
+  popCurrentOrder() {
+    this.pullNextPlayerOrder();
   }
 }

--- a/apps/client/src/app/probable-waffle/game/entity/character/ai/pawn-ai-blackboard.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/character/ai/pawn-ai-blackboard.ts
@@ -53,9 +53,8 @@ export class PawnAiBlackboard extends Blackboard {
   }
 
   overrideOrderQueueAndActiveOrder(orderData: OrderData): void {
-    this.orderQueue = [orderData];
     this.resetCurrentOrder();
-    this.status = "idle";
+    this.orderQueue = [orderData];
   }
 
   resetCurrentOrder(callCancellationHandler: boolean = true): void {
@@ -85,7 +84,7 @@ export class PawnAiBlackboard extends Blackboard {
     return [...this.failedOrders];
   }
 
-  popCurrentOrder() {
+  popCurrentOrderFromQueue() {
     this.pullNextPlayerOrder();
   }
 }

--- a/apps/client/src/app/probable-waffle/game/entity/character/ai/pawn-ai-blackboard.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/character/ai/pawn-ai-blackboard.ts
@@ -1,14 +1,77 @@
 import { Blackboard } from "./blackboard";
-import { OrderType } from "./order-type";
-import { Vector3Simple } from "@fuzzy-waddle/api-interfaces";
-import GameObject = Phaser.GameObjects.GameObject;
+import { OrderData } from "./OrderData";
 
 export class PawnAiBlackboard extends Blackboard {
-  playerOrderType?: OrderType;
-  aiOrderType?: OrderType;
-  targetGameObject?: GameObject;
-  targetLocation?: Vector3Simple;
-  // range?: number;
-  // acceptanceRadius?: number;
-  // buildingType?: string;
+  private orderQueue: OrderData[] = [];
+  private currentOrder?: OrderData;
+  private memory: Map<string, any> = new Map();
+  private status: "idle" | "executing" | "paused" = "idle";
+  private failedOrders: OrderData[] = [];
+
+  getStatus(): string {
+    return this.status;
+  }
+
+  setStatus(newStatus: "idle" | "executing" | "paused"): void {
+    this.status = newStatus;
+  }
+
+  addOrder(order: OrderData): void {
+    this.orderQueue.push(order);
+  }
+
+  anyOrderInQueue(): boolean {
+    return !!this.orderQueue.length;
+  }
+
+  pullNextPlayerOrder(): OrderData | undefined {
+    return this.orderQueue.shift();
+  }
+
+  peekNextPlayerOrder(): OrderData | undefined {
+    if (this.orderQueue.length) {
+      return this.orderQueue[0];
+    }
+    return undefined;
+  }
+
+  getCurrentOrder(): OrderData | undefined {
+    return this.currentOrder;
+  }
+
+  setCurrentOrder(order?: OrderData): void {
+    this.currentOrder = order;
+  }
+
+  resetAll(): void {
+    this.orderQueue = [];
+    this.resetCurrentOrder();
+    this.memory.clear();
+    this.failedOrders = [];
+    this.status = "idle";
+  }
+
+  resetCurrentOrder(): void {
+    this.currentOrder = undefined;
+  }
+
+  remember<T>(key: string, value: T): void {
+    this.memory.set(key, value);
+  }
+
+  recall<T>(key: string): T | undefined {
+    return this.memory.get(key);
+  }
+
+  forget(key: string): void {
+    this.memory.delete(key);
+  }
+
+  addFailedOrder(order: OrderData): void {
+    this.failedOrders.push(order);
+  }
+
+  getFailedOrders(): OrderData[] {
+    return [...this.failedOrders];
+  }
 }

--- a/apps/client/src/app/probable-waffle/game/entity/combat/components/attack-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/combat/components/attack-component.ts
@@ -10,7 +10,7 @@ export type AttackDefinition = {
 
 export class AttackComponent {
   // when cooldown has expired
-  onCooldownReady: EventEmitter<GameObject> = new EventEmitter<GameObject>();
+  // onCooldownReady: EventEmitter<GameObject> = new EventEmitter<GameObject>();
   // gameObject used an attack
   onAttackUsed: EventEmitter<AttackData> = new EventEmitter<AttackData>();
   remainingCooldown = 0;
@@ -27,14 +27,15 @@ export class AttackComponent {
   private destroy() {
     this.owner.scene.events.off(Phaser.Scenes.Events.UPDATE, this.update, this);
   }
-  private update(time: number, delta: number): void {
+  private update(_: number, delta: number): void {
     if (this.remainingCooldown <= 0) {
       return;
     }
     this.remainingCooldown -= delta;
-    if (this.remainingCooldown <= 0) {
-      this.onCooldownReady.emit(this.owner);
-    }
+    this.remainingCooldown = Math.max(this.remainingCooldown, 0);
+    // if (this.remainingCooldown <= 0) {
+    //   this.onCooldownReady.emit(this.owner);
+    // }
   }
 
   get primaryAttack(): number | null {

--- a/apps/client/src/app/probable-waffle/game/entity/combat/components/attack-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/combat/components/attack-component.ts
@@ -59,9 +59,7 @@ export class AttackComponent {
       // todo   projectile.fireAtGameObject(enemy);
     } else {
       const enemyHealthComponent = getActorComponent(enemy, HealthComponent);
-      if (!enemyHealthComponent) {
-        throw new Error("Enemy does not have HealthComponent");
-      }
+      if (!enemyHealthComponent) return;
       enemyHealthComponent.takeDamage(attack.damage, attack.damageType, this.owner);
     }
 

--- a/apps/client/src/app/probable-waffle/game/entity/combat/components/healing-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/combat/components/healing-component.ts
@@ -2,7 +2,8 @@ import { getActorComponent } from "../../../data/actor-component";
 import { HealthComponent } from "./health-component";
 
 export type HealingDefinition = {
-  healPerSecond: number;
+  healPerCooldown: number;
+  cooldown: number;
   range: number;
 };
 
@@ -32,7 +33,8 @@ export class HealingComponent {
   heal(target: Phaser.GameObjects.GameObject) {
     const targetHealthComponent = getActorComponent(target, HealthComponent);
     if (!targetHealthComponent) return;
-    targetHealthComponent.heal(this.healingDefinition.healPerSecond);
+    targetHealthComponent.heal(this.healingDefinition.healPerCooldown);
+    this.remainingCooldown = this.healingDefinition.cooldown;
   }
 
   getHealRange() {

--- a/apps/client/src/app/probable-waffle/game/entity/combat/components/healing-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/combat/components/healing-component.ts
@@ -1,0 +1,18 @@
+import { getActorComponent } from "../../../data/actor-component";
+import { HealthComponent } from "./health-component";
+
+export type HealingDefinition = {
+  healPerSecond: number;
+};
+
+export class HealingComponent {
+  constructor(
+    private readonly gameObject: Phaser.GameObjects.GameObject,
+    public readonly healingDefinition: HealingDefinition
+  ) {}
+  heal(target: Phaser.GameObjects.GameObject) {
+    const targetHealthComponent = getActorComponent(target, HealthComponent);
+    if (!targetHealthComponent) return;
+    targetHealthComponent.heal(this.healingDefinition.healPerSecond);
+  }
+}

--- a/apps/client/src/app/probable-waffle/game/entity/combat/components/healing-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/combat/components/healing-component.ts
@@ -1,7 +1,5 @@
 import { getActorComponent } from "../../../data/actor-component";
 import { HealthComponent } from "./health-component";
-import { EventEmitter } from "@angular/core";
-import GameObject = Phaser.GameObjects.GameObject;
 
 export type HealingDefinition = {
   healPerSecond: number;
@@ -9,7 +7,7 @@ export type HealingDefinition = {
 };
 
 export class HealingComponent {
-  onCooldownReady: EventEmitter<GameObject> = new EventEmitter<GameObject>();
+  // onCooldownReady: EventEmitter<GameObject> = new EventEmitter<GameObject>();
   remainingCooldown = 0;
   constructor(
     private readonly gameObject: Phaser.GameObjects.GameObject,
@@ -20,14 +18,15 @@ export class HealingComponent {
     gameObject.once(HealthComponent.KilledEvent, this.destroy, this);
   }
 
-  private update(time: number, delta: number): void {
+  private update(_: number, delta: number): void {
     if (this.remainingCooldown <= 0) {
       return;
     }
     this.remainingCooldown -= delta;
-    if (this.remainingCooldown <= 0) {
-      this.onCooldownReady.emit(this.gameObject);
-    }
+    this.remainingCooldown = Math.max(this.remainingCooldown, 0);
+    // if (this.remainingCooldown <= 0) {
+    //   this.onCooldownReady.emit(this.gameObject);
+    // }
   }
 
   heal(target: Phaser.GameObjects.GameObject) {

--- a/apps/client/src/app/probable-waffle/game/entity/combat/components/healing-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/combat/components/healing-component.ts
@@ -1,18 +1,46 @@
 import { getActorComponent } from "../../../data/actor-component";
 import { HealthComponent } from "./health-component";
+import { EventEmitter } from "@angular/core";
+import GameObject = Phaser.GameObjects.GameObject;
 
 export type HealingDefinition = {
   healPerSecond: number;
+  range: number;
 };
 
 export class HealingComponent {
+  onCooldownReady: EventEmitter<GameObject> = new EventEmitter<GameObject>();
+  remainingCooldown = 0;
   constructor(
     private readonly gameObject: Phaser.GameObjects.GameObject,
     public readonly healingDefinition: HealingDefinition
-  ) {}
+  ) {
+    gameObject.scene.events.on(Phaser.Scenes.Events.UPDATE, this.update, this);
+    gameObject.once(Phaser.GameObjects.Events.DESTROY, this.destroy, this);
+    gameObject.once(HealthComponent.KilledEvent, this.destroy, this);
+  }
+
+  private update(time: number, delta: number): void {
+    if (this.remainingCooldown <= 0) {
+      return;
+    }
+    this.remainingCooldown -= delta;
+    if (this.remainingCooldown <= 0) {
+      this.onCooldownReady.emit(this.gameObject);
+    }
+  }
+
   heal(target: Phaser.GameObjects.GameObject) {
     const targetHealthComponent = getActorComponent(target, HealthComponent);
     if (!targetHealthComponent) return;
     targetHealthComponent.heal(this.healingDefinition.healPerSecond);
+  }
+
+  getHealRange() {
+    return this.healingDefinition.range;
+  }
+
+  private destroy() {
+    this.gameObject.scene.events.off(Phaser.Scenes.Events.UPDATE, this.update, this);
   }
 }

--- a/apps/client/src/app/probable-waffle/game/entity/combat/components/health-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/combat/components/health-component.ts
@@ -9,6 +9,10 @@ import Phaser from "phaser";
 import { getActorComponent } from "../../../data/actor-component";
 import { ConstructionSiteComponent } from "../../building/construction/construction-site-component";
 import { onObjectReady } from "../../../data/game-object-helper";
+import { environment } from "../../../../../../environments/environment";
+import { SelectableComponent } from "../../actor/components/selectable-component";
+import { OwnerComponent } from "../../actor/components/owner-component";
+import { getCurrentPlayerNumber } from "../../../data/scene-data";
 
 export type HealthDefinition = {
   maxHealth: number;
@@ -63,6 +67,8 @@ export class HealthComponent {
   private shouldUiElementsBeVisible: boolean = false;
   private constructionProgressSubscription?: Subscription;
   private healthUiHideOnTimeout?: number;
+  private killKey?: Phaser.Input.Keyboard.Key | undefined;
+  private damageKey?: Phaser.Input.Keyboard.Key | undefined;
   constructor(
     private readonly gameObject: Phaser.GameObjects.GameObject,
     public readonly healthDefinition: HealthDefinition
@@ -108,6 +114,48 @@ export class HealthComponent {
         this.setVisibilityUiComponent(this.shouldUiElementsBeVisible)
       );
     }
+
+    this.bindKillKey();
+
+    if (!environment.production) {
+      this.bindDamageKey();
+    }
+  }
+
+  private bindKillKey() {
+    this.killKey = this.gameObject.scene.input.keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.DELETE);
+    if (!this.killKey) return;
+    this.killKey.on(Phaser.Input.Keyboard.Events.DOWN, this.killSelected, this);
+  }
+
+  private killSelected() {
+    if (!this.canDamageOrKillOnKeyboardAction()) return;
+    this.killActor();
+  }
+
+  private bindDamageKey() {
+    this.damageKey = this.gameObject.scene.input.keyboard?.addKey(Phaser.Input.Keyboard.KeyCodes.P);
+    if (!this.damageKey) return;
+    this.damageKey.on(Phaser.Input.Keyboard.Events.DOWN, this.damageSelected, this);
+  }
+
+  private damageSelected() {
+    if (!this.canDamageOrKillOnKeyboardAction()) return;
+    this.takeDamage(1, DamageType.Physical);
+  }
+
+  private canDamageOrKillOnKeyboardAction(): boolean {
+    const selectionComponent = getActorComponent(this.gameObject, SelectableComponent);
+    if (!selectionComponent) return false;
+    if (!selectionComponent.getSelected()) return false;
+    const ownerComponent = getActorComponent(this.gameObject, OwnerComponent);
+    if (!ownerComponent) return false;
+    const currentPlayerNumber = getCurrentPlayerNumber(this.gameObject.scene);
+    if (currentPlayerNumber === undefined) return false;
+    if (ownerComponent.getOwner() !== currentPlayerNumber) return false;
+    // noinspection RedundantIfStatementJS
+    if (!this.alive) return false;
+    return true;
   }
 
   private gameObjectVisibilityChanged(visible: boolean) {
@@ -210,6 +258,16 @@ export class HealthComponent {
     this.playerChangedSubscription?.unsubscribe();
     this.constructionProgressSubscription?.unsubscribe();
     this.gameObject.off(ContainerComponent.GameObjectVisibilityChanged, this.gameObjectVisibilityChanged, this);
+    this.killKey?.off(Phaser.Input.Keyboard.Events.DOWN, this.killSelected, this);
+    this.damageKey?.off(Phaser.Input.Keyboard.Events.DOWN, this.damageSelected, this);
+  }
+
+  get alive(): boolean {
+    return this.healthComponentData.health > 0;
+  }
+
+  get killed(): boolean {
+    return !this.alive;
   }
 
   getData(): HealthComponentData {
@@ -220,7 +278,11 @@ export class HealthComponent {
     this.healthComponentData = { ...this.healthComponentData, ...data };
   }
 
-  isDamaged() {
-    return this.healthComponentData.health < this.healthDefinition.maxHealth;
+  get isDamaged() {
+    return this.healthComponentData.health < this.healthDefinition.maxHealth && this.alive;
+  }
+
+  get healthIsFull() {
+    return this.healthComponentData.health === this.healthDefinition.maxHealth;
   }
 }

--- a/apps/client/src/app/probable-waffle/game/entity/combat/components/health-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/combat/components/health-component.ts
@@ -157,6 +157,13 @@ export class HealthComponent {
     }
   }
 
+  heal(amount: number) {
+    this.healthComponentData.health = Math.min(
+      this.healthComponentData.health + amount,
+      this.healthDefinition.maxHealth
+    );
+  }
+
   killActor() {
     this.healthComponentData.health = 0;
     this.gameObject.emit(HealthComponent.KilledEvent);
@@ -211,5 +218,9 @@ export class HealthComponent {
 
   setData(data: Partial<HealthComponentData>) {
     this.healthComponentData = { ...this.healthComponentData, ...data };
+  }
+
+  isDamaged() {
+    return this.healthComponentData.health < this.healthDefinition.maxHealth;
   }
 }

--- a/apps/client/src/app/probable-waffle/game/entity/systems/action.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/action.system.ts
@@ -98,7 +98,7 @@ export class ActionSystem {
 
             const targetHealthComponent = getActorComponent(targetGameObject, HealthComponent);
             if (targetHealthComponent) {
-              if (targetHealthComponent.isDamaged()) {
+              if (targetHealthComponent.isDamaged) {
                 // building is damaged
 
                 const selfBuilderComponent = getActorComponent(this.gameObject, BuilderComponent);
@@ -113,7 +113,7 @@ export class ActionSystem {
 
           const targetHealthComponent = getActorComponent(targetGameObject, HealthComponent);
           if (targetHealthComponent) {
-            if (targetHealthComponent.isDamaged()) {
+            if (targetHealthComponent.isDamaged) {
               // target is damaged
 
               const selfBuilderComponent = getActorComponent(this.gameObject, HealingComponent);

--- a/apps/client/src/app/probable-waffle/game/entity/systems/action.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/action.system.ts
@@ -1,0 +1,190 @@
+import { onObjectReady } from "../../data/game-object-helper";
+import { Subscription } from "rxjs";
+import { getCommunicator } from "../../data/scene-data";
+import { SelectableComponent } from "../actor/components/selectable-component";
+import { getActorComponent } from "../../data/actor-component";
+import { HealthComponent } from "../combat/components/health-component";
+import { PawnAiController } from "../../world/managers/controllers/player-pawn-ai-controller/pawn-ai-controller";
+import { IdComponent } from "../actor/components/id-component";
+import { AttackComponent } from "../combat/components/attack-component";
+import { OrderData } from "../character/ai/OrderData";
+import { OrderType } from "../character/ai/order-type";
+import { GathererComponent } from "../actor/components/gatherer-component";
+import { ResourceDrainComponent } from "../economy/resource/resource-drain-component";
+import { OwnerComponent } from "../actor/components/owner-component";
+import { ConstructionSiteComponent } from "../building/construction/construction-site-component";
+import { BuilderComponent } from "../actor/components/builder-component";
+import { ActorTranslateComponent } from "../actor/components/actor-translate-component";
+import { HealingComponent } from "../combat/components/healing-component";
+import { ContainerComponent } from "../building/container-component";
+import { ResourceSourceComponent } from "../economy/resource/resource-source-component";
+import { environment } from "../../../../../environments/environment";
+import { getSceneService } from "../../scenes/components/scene-component-helpers";
+import { DebuggingService } from "../../scenes/services/DebuggingService";
+import { ContainableComponent } from "../actor/components/containable-component";
+
+export class ActionSystem {
+  private playerChangedSubscription?: Subscription;
+  private aiDebuggingSubscription?: Subscription;
+  private displayDebugInfo: boolean = false;
+
+  constructor(private readonly gameObject: Phaser.GameObjects.GameObject) {
+    this.listenToActorActionEvents();
+    onObjectReady(gameObject, this.init, this);
+    gameObject.once(Phaser.GameObjects.Events.DESTROY, this.destroy);
+    gameObject.once(HealthComponent.KilledEvent, this.destroy, this);
+  }
+
+  private init() {
+    if (!environment.production) {
+      const aiDebuggingService = getSceneService(this.gameObject.scene, DebuggingService)!;
+      this.aiDebuggingSubscription = aiDebuggingService.debugChanged.subscribe((debug) => {
+        this.displayDebugInfo = debug;
+      });
+    }
+  }
+
+  private listenToActorActionEvents() {
+    this.playerChangedSubscription = getCommunicator(this.gameObject.scene)
+      .playerChanged?.onWithFilter((p) => p.property === "command.issued.actor") // todo it's actually blackboard that should replicate
+      .subscribe((payload) => {
+        const isSelected = getActorComponent(this.gameObject, SelectableComponent)?.getSelected();
+        if (!isSelected) return;
+        const payerPawnAiController = getActorComponent(this.gameObject, PawnAiController);
+        if (!payerPawnAiController) return;
+
+        const objectIds = payload.data.data!["objectIds"] as string[];
+        const clickedGameObjects = this.gameObject.scene.children.list.filter((go) =>
+          objectIds.includes(getActorComponent(go, IdComponent)?.id ?? "")
+        );
+
+        if (clickedGameObjects.length === 0) return;
+        const clickedGameObject = clickedGameObjects[0];
+        const action = this.findAction(clickedGameObject);
+        if (!action) return;
+
+        if (this.displayDebugInfo && !environment.production) console.log("ActionSystem: action", action);
+        payerPawnAiController.blackboard.overrideOrderQueueAndActiveOrder(action);
+      });
+  }
+
+  private findAction(targetGameObject: Phaser.GameObjects.GameObject): OrderData | null {
+    const targetOwnerComponent = getActorComponent(targetGameObject, OwnerComponent);
+    if (targetOwnerComponent) {
+      // player object
+
+      const targetPlayerNumber = targetOwnerComponent.getOwner();
+      const selfOwnerComponent = getActorComponent(this.gameObject, OwnerComponent);
+      if (!selfOwnerComponent) throw new Error("OwnerComponent not found when trying to find action");
+      const selfPlayerNumber = selfOwnerComponent.getOwner();
+      if (selfPlayerNumber === targetPlayerNumber) {
+        // ally
+
+        const targetIsBuilding = getActorComponent(targetGameObject, ConstructionSiteComponent);
+        if (targetIsBuilding) {
+          // target is building
+
+          if (!targetIsBuilding.isFinished()) {
+            // Building is not finished
+
+            const selfBuilderComponent = getActorComponent(this.gameObject, BuilderComponent);
+            if (selfBuilderComponent) {
+              // self is builder
+
+              return new OrderData(OrderType.Build, { targetGameObject });
+            }
+          } else {
+            // building is finished
+
+            const targetHealthComponent = getActorComponent(targetGameObject, HealthComponent);
+            if (targetHealthComponent) {
+              if (targetHealthComponent.isDamaged()) {
+                // building is damaged
+
+                const selfBuilderComponent = getActorComponent(this.gameObject, BuilderComponent);
+                if (selfBuilderComponent) {
+                  return new OrderData(OrderType.Repair, { targetGameObject });
+                }
+              }
+            }
+          }
+        } else {
+          // target is not building
+
+          const targetHealthComponent = getActorComponent(targetGameObject, HealthComponent);
+          if (targetHealthComponent) {
+            if (targetHealthComponent.isDamaged()) {
+              // target is damaged
+
+              const selfBuilderComponent = getActorComponent(this.gameObject, HealingComponent);
+              if (selfBuilderComponent) {
+                return new OrderData(OrderType.Heal, { targetGameObject });
+              }
+            }
+          }
+        }
+
+        const targetIsResourceDrain = getActorComponent(targetGameObject, ResourceDrainComponent);
+        if (targetIsResourceDrain) {
+          // target is resource drain
+
+          const selfGathererComponent = getActorComponent(this.gameObject, GathererComponent);
+          if (selfGathererComponent) {
+            // self is gatherer
+
+            return new OrderData(OrderType.ReturnResources, { targetGameObject });
+          }
+        }
+
+        const targetIsContainer = getActorComponent(targetGameObject, ContainerComponent);
+        if (targetIsContainer) {
+          // target is container
+
+          const selfContainableComponent = getActorComponent(this.gameObject, ContainableComponent);
+          if (selfContainableComponent) {
+            // self is containable
+
+            return new OrderData(OrderType.EnterContainer, { targetGameObject });
+          }
+        }
+      } else {
+        // enemy
+
+        const selfAttackComponent = getActorComponent(this.gameObject, AttackComponent);
+        if (selfAttackComponent) {
+          // self is attacker
+
+          return new OrderData(OrderType.Attack, { targetGameObject });
+        }
+      }
+    } else {
+      // non-player object like resources
+
+      const targetResourceSource = getActorComponent(targetGameObject, ResourceSourceComponent);
+      if (targetResourceSource) {
+        // target is resource source
+
+        const selfGathererComponent = getActorComponent(this.gameObject, GathererComponent);
+        if (selfGathererComponent) {
+          // self is gatherer
+
+          return new OrderData(OrderType.Gather, { targetGameObject });
+        }
+      }
+    }
+
+    const selfHasMovementComponent = getActorComponent(this.gameObject, ActorTranslateComponent);
+    if (selfHasMovementComponent) {
+      // self can move
+
+      return new OrderData(OrderType.Move, { targetGameObject });
+    }
+
+    return null;
+  }
+
+  private destroy() {
+    this.playerChangedSubscription?.unsubscribe();
+    this.aiDebuggingSubscription?.unsubscribe();
+  }
+}

--- a/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
@@ -138,8 +138,7 @@ export class MovementSystem {
 
     if (!this.navigationService) return false;
 
-    const path = await this.navigationService.findAndUseWalkablePathBetweenGameObjectsWithRadius(
-      this.gameObject,
+    const path = await this.getPathToClosestWalkableTileBetweenGameObjectsInRadius(
       gameObject,
       pathMoveConfig?.radiusTilesAroundDestination
     );
@@ -265,14 +264,20 @@ export class MovementSystem {
   }
 
   async canMoveTo(targetGameObject: Phaser.GameObjects.GameObject, range?: number): Promise<boolean> {
-    if (!this.navigationService) return false;
+    const path = await this.getPathToClosestWalkableTileBetweenGameObjectsInRadius(targetGameObject, range);
+    return path.length > 0;
+  }
 
-    const path = await this.navigationService.findAndUseWalkablePathBetweenGameObjectsWithRadius(
+  async getPathToClosestWalkableTileBetweenGameObjectsInRadius(
+    targetGameObject: Phaser.GameObjects.GameObject,
+    range?: number
+  ): Promise<Vector2Simple[]> {
+    if (!this.navigationService) return [];
+    return await this.navigationService.findAndUseWalkablePathBetweenGameObjectsWithRadius(
       this.gameObject,
       targetGameObject,
       range
     );
-    return path.length > 0;
   }
 }
 

--- a/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
@@ -61,27 +61,18 @@ export class MovementSystem {
     this.playerChangedSubscription = getCommunicator(this.gameObject.scene)
       .playerChanged?.onWithFilter((p) => p.property === "command.issued.move") // todo it's actually blackboard that should replicate
       .subscribe((payload) => {
-        switch (payload.property) {
-          case "command.issued.move":
-            const tileVec3 = payload.data.data!["tileVec3"] as Vector3Simple;
-            const isSelected = getActorComponent(this.gameObject, SelectableComponent)?.getSelected();
-            if (isSelected) {
-              // todo, note that we may also navigate to object and not to the tile under the object - use this.moveToActor(gameObject)
-
-              const payerPawnAiController = getActorComponent(this.gameObject, PawnAiController);
-              if (payerPawnAiController) {
-                payerPawnAiController.blackboard.overrideOrderQueueAndActiveOrder(
-                  new OrderData(OrderType.Move, { targetLocation: tileVec3 })
-                );
-              } else {
-                this.moveToLocation(tileVec3);
-              }
-            }
-            break;
+        const isSelected = getActorComponent(this.gameObject, SelectableComponent)?.getSelected();
+        if (!isSelected) return;
+        const tileVec3 = payload.data.data!["tileVec3"] as Vector3Simple;
+        const payerPawnAiController = getActorComponent(this.gameObject, PawnAiController);
+        if (payerPawnAiController) {
+          payerPawnAiController.blackboard.overrideOrderQueueAndActiveOrder(
+            new OrderData(OrderType.Move, { targetLocation: tileVec3 })
+          );
+        } else {
+          this.moveToLocation(tileVec3);
         }
       });
-
-    // todo this needs to be removed from here, and add this to the pawn ai controller which will then accordingly to blackboard issue MovementSystem.moveToLocation
   }
 
   // todo this should maybe later move to component like ActorTransform which will also broadcast event for transform to game and update actors depth

--- a/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
@@ -70,8 +70,9 @@ export class MovementSystem {
 
               const payerPawnAiController = getActorComponent(this.gameObject, PawnAiController);
               if (payerPawnAiController) {
-                payerPawnAiController.blackboard.resetAll();
-                payerPawnAiController.blackboard.addOrder(new OrderData(OrderType.Move, { targetLocation: tileVec3 }));
+                payerPawnAiController.blackboard.overrideOrderQueueAndActiveOrder(
+                  new OrderData(OrderType.Move, { targetLocation: tileVec3 })
+                );
               } else {
                 this.moveToLocation(tileVec3);
               }
@@ -219,7 +220,10 @@ export class MovementSystem {
   };
 
   cancelMovement() {
-    this._currentTween?.stop();
+    if (this._currentTween) {
+      this._currentTween.stop();
+      this._currentTween = undefined;
+    }
   }
 
   private moveDirectlyToLocation(vec3: Vector3Simple, pathMoveConfig: PathMoveConfig): Promise<void> {

--- a/apps/client/src/app/probable-waffle/game/library/gameplay-library.ts
+++ b/apps/client/src/app/probable-waffle/game/library/gameplay-library.ts
@@ -89,4 +89,13 @@ export class GameplayLibrary {
     const distance = Math.sqrt(Math.pow(actor1Tile.x - actor2Tile.x, 2) + Math.pow(actor1Tile.y - actor2Tile.y, 2));
     return Math.floor(distance);
   }
+
+  static getTileDistanceBetweenGameObjectAndTile(actor: GameObject, tile: Vector3Simple): number | null {
+    const actorTile = getGameObjectCurrentTile(actor);
+    if (!actorTile) return null;
+
+    // noinspection UnnecessaryLocalVariableJS
+    const distance = Math.sqrt(Math.pow(actorTile.x - tile.x, 2) + Math.pow(actorTile.y - tile.y, 2));
+    return Math.floor(distance);
+  }
 }

--- a/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.scene
+++ b/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.scene
@@ -1,0 +1,72 @@
+{
+    "id": "dba459ed-b5e7-4548-9d60-a8837740d255",
+    "sceneType": "SCENE",
+    "settings": {
+        "compilerInsertSpaces": true,
+        "compilerTabSize": 2,
+        "snapEnabled": true,
+        "snapWidth": 32,
+        "exportClass": true,
+        "autoImport": true,
+        "superClassName": "GameProbableWaffleScene",
+        "preloadPackFiles": [],
+        "createMethodName": "editorCreate",
+        "sceneKey": "MapSandbox",
+        "compilerOutputLanguage": "TYPE_SCRIPT",
+        "borderWidth": 1280,
+        "borderHeight": 720
+    },
+    "displayList": [
+        {
+            "type": "TilemapLayer",
+            "id": "9cdf4f18-3323-43bf-b105-00fddbdbc7e6",
+            "label": "tilemap_level_1",
+            "tilemapId": "9cb0db04-e78b-4290-b950-d943f1631f3c",
+            "layerName": "TileMap_level_1",
+            "tilesets": [
+                "tiles",
+                "tiles_2"
+            ]
+        },
+        {
+            "prefabId": "edf32147-e546-4f6e-91ba-1720c6b75ac9",
+            "id": "995e2abe-47e3-4715-85aa-ab35a85fb09f",
+            "unlock": [
+                "x",
+                "y"
+            ],
+            "label": "tivaraWorkerMale",
+            "components": [
+                "EditorOwner"
+            ],
+            "EditorOwner.owner_id": "1",
+            "x": 40,
+            "y": 650
+        }
+    ],
+    "plainObjects": [
+        {
+            "id": "9cb0db04-e78b-4290-b950-d943f1631f3c",
+            "type": "Tilemap",
+            "label": "tilemap",
+            "scope": "PUBLIC",
+            "key": "tiles_river_crossing",
+            "tilesets": [
+                {
+                    "name": "tiles",
+                    "imageKey": "tiles_1"
+                },
+                {
+                    "name": "tiles_2",
+                    "imageKey": "tiles_2"
+                }
+            ]
+        }
+    ],
+    "meta": {
+        "app": "Phaser Editor - Scene Editor",
+        "url": "https://phaser.io/editor",
+        "contentType": "phasereditor2d.core.scene.SceneContentType",
+        "version": 5
+    }
+}

--- a/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.scene
+++ b/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.scene
@@ -42,6 +42,47 @@
             "EditorOwner.owner_id": "1",
             "x": 40,
             "y": 650
+        },
+        {
+            "prefabId": "ec58b20e-e04f-4bd3-840e-856ffe433f23",
+            "id": "e0b3669c-7bac-4a27-94db-c5da471f53c8",
+            "unlock": [
+                "x",
+                "y"
+            ],
+            "label": "workMill",
+            "components": [
+                "EditorOwner"
+            ],
+            "EditorOwner.owner_id": "2",
+            "x": 448,
+            "y": 736
+        },
+        {
+            "prefabId": "f09568ca-4e05-4ddd-ba4f-3ad6c515d28b",
+            "id": "3c9fde9f-77b3-458c-9ebb-bbe97c3a8870",
+            "unlock": [
+                "x",
+                "y"
+            ],
+            "label": "tree11",
+            "x": -160,
+            "y": 416
+        },
+        {
+            "prefabId": "ec58b20e-e04f-4bd3-840e-856ffe433f23",
+            "id": "7dec28fb-7251-4ac5-a799-5fc4d59c074c",
+            "unlock": [
+                "x",
+                "y"
+            ],
+            "label": "workMill_1",
+            "components": [
+                "EditorOwner"
+            ],
+            "EditorOwner.owner_id": "1",
+            "x": -352,
+            "y": 576
         }
     ],
     "plainObjects": [

--- a/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.scene
+++ b/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.scene
@@ -83,6 +83,21 @@
             "EditorOwner.owner_id": "1",
             "x": -352,
             "y": 576
+        },
+        {
+            "prefabId": "6c2cf0db-4461-4b32-b5d3-9882c5326e1b",
+            "id": "d5d32a63-a668-4046-952a-67a74abbafbe",
+            "unlock": [
+                "x",
+                "y"
+            ],
+            "label": "tivaraSlingshotFemale",
+            "components": [
+                "EditorOwner"
+            ],
+            "EditorOwner.owner_id": "1",
+            "x": 224,
+            "y": 560
         }
     ],
     "plainObjects": [

--- a/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.ts
+++ b/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.ts
@@ -5,6 +5,8 @@
 import GameProbableWaffleScene from "./GameProbableWaffleScene";
 import TivaraWorkerMale from "../prefabs/characters/tivara/TivaraWorkerMale";
 import EditorOwner from "../editor-components/EditorOwner";
+import WorkMill from "../prefabs/buildings/tivara/WorkMill";
+import Tree11 from "../prefabs/outside/foliage/trees/resources/Tree11";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 
@@ -32,9 +34,29 @@ export default class MapSandbox extends GameProbableWaffleScene {
     const tivaraWorkerMale = new TivaraWorkerMale(this, 40, 650);
     this.add.existing(tivaraWorkerMale);
 
+    // workMill
+    const workMill = new WorkMill(this, 448, 736);
+    this.add.existing(workMill);
+
+    // tree11
+    const tree11 = new Tree11(this, -160, 416);
+    this.add.existing(tree11);
+
+    // workMill_1
+    const workMill_1 = new WorkMill(this, -352, 576);
+    this.add.existing(workMill_1);
+
     // tivaraWorkerMale (components)
     const tivaraWorkerMaleEditorOwner = new EditorOwner(tivaraWorkerMale);
     tivaraWorkerMaleEditorOwner.owner_id = "1";
+
+    // workMill (components)
+    const workMillEditorOwner = new EditorOwner(workMill);
+    workMillEditorOwner.owner_id = "2";
+
+    // workMill_1 (components)
+    const workMill_1EditorOwner = new EditorOwner(workMill_1);
+    workMill_1EditorOwner.owner_id = "1";
 
     this.tilemap = tilemap;
 

--- a/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.ts
+++ b/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.ts
@@ -1,0 +1,57 @@
+// You can write more code here
+
+/* START OF COMPILED CODE */
+
+import GameProbableWaffleScene from "./GameProbableWaffleScene";
+import TivaraWorkerMale from "../prefabs/characters/tivara/TivaraWorkerMale";
+import EditorOwner from "../editor-components/EditorOwner";
+/* START-USER-IMPORTS */
+/* END-USER-IMPORTS */
+
+export default class MapSandbox extends GameProbableWaffleScene {
+
+  constructor() {
+    super("MapSandbox");
+
+    /* START-USER-CTR-CODE */
+    // Write your code here.
+    /* END-USER-CTR-CODE */
+  }
+
+  editorCreate(): void {
+
+    // tilemap
+    const tilemap = this.add.tilemap("tiles_river_crossing");
+    tilemap.addTilesetImage("tiles", "tiles_1");
+    tilemap.addTilesetImage("tiles_2", "tiles_2");
+
+    // tilemap_level_1
+    tilemap.createLayer("TileMap_level_1", ["tiles","tiles_2"], 0, 0);
+
+    // tivaraWorkerMale
+    const tivaraWorkerMale = new TivaraWorkerMale(this, 40, 650);
+    this.add.existing(tivaraWorkerMale);
+
+    // tivaraWorkerMale (components)
+    const tivaraWorkerMaleEditorOwner = new EditorOwner(tivaraWorkerMale);
+    tivaraWorkerMaleEditorOwner.owner_id = "1";
+
+    this.tilemap = tilemap;
+
+    this.events.emit("scene-awake");
+  }
+
+  public tilemap!: Phaser.Tilemaps.Tilemap;
+
+  /* START-USER-CODE */
+  create() {
+    this.editorCreate();
+
+    super.create();
+  }
+  /* END-USER-CODE */
+}
+
+/* END OF COMPILED CODE */
+
+// You can write more code here

--- a/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.ts
+++ b/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.ts
@@ -7,6 +7,7 @@ import TivaraWorkerMale from "../prefabs/characters/tivara/TivaraWorkerMale";
 import EditorOwner from "../editor-components/EditorOwner";
 import WorkMill from "../prefabs/buildings/tivara/WorkMill";
 import Tree11 from "../prefabs/outside/foliage/trees/resources/Tree11";
+import TivaraSlingshotFemale from "../prefabs/characters/tivara/TivaraSlingshotFemale";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 
@@ -46,6 +47,10 @@ export default class MapSandbox extends GameProbableWaffleScene {
     const workMill_1 = new WorkMill(this, -352, 576);
     this.add.existing(workMill_1);
 
+    // tivaraSlingshotFemale
+    const tivaraSlingshotFemale = new TivaraSlingshotFemale(this, 224, 560);
+    this.add.existing(tivaraSlingshotFemale);
+
     // tivaraWorkerMale (components)
     const tivaraWorkerMaleEditorOwner = new EditorOwner(tivaraWorkerMale);
     tivaraWorkerMaleEditorOwner.owner_id = "1";
@@ -57,6 +62,10 @@ export default class MapSandbox extends GameProbableWaffleScene {
     // workMill_1 (components)
     const workMill_1EditorOwner = new EditorOwner(workMill_1);
     workMill_1EditorOwner.owner_id = "1";
+
+    // tivaraSlingshotFemale (components)
+    const tivaraSlingshotFemaleEditorOwner = new EditorOwner(tivaraSlingshotFemale);
+    tivaraSlingshotFemaleEditorOwner.owner_id = "1";
 
     this.tilemap = tilemap;
 

--- a/apps/client/src/app/probable-waffle/game/world/const/game-config.ts
+++ b/apps/client/src/app/probable-waffle/game/world/const/game-config.ts
@@ -7,11 +7,20 @@ import { Boot } from "../../scenes/Boot";
 import MapEmberEnclave from "../../scenes/MapEmberEnclave";
 import HudProbableWaffle from "../../scenes/HudProbableWaffle";
 import GameActionsLayer from "../../scenes/GameActionsLayer";
+import MapSandbox from "../../scenes/MapSandbox";
 
 export const probableWaffleGameConfig: Types.Core.GameConfig = {
   ...baseGameConfig,
   // scene: [GrasslandScene, PlaygroundScene],
-  scene: [Boot, PreloadProbableWaffle, MapRiverCrossing, MapEmberEnclave, HudProbableWaffle, GameActionsLayer],
+  scene: [
+    Boot,
+    PreloadProbableWaffle,
+    MapSandbox,
+    MapRiverCrossing,
+    MapEmberEnclave,
+    HudProbableWaffle,
+    GameActionsLayer
+  ],
   physics: {
     default: "arcade",
     arcade: {

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/input/game-object-selection.handler.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/input/game-object-selection.handler.ts
@@ -4,7 +4,12 @@ import { getActorComponent } from "../../../../data/actor-component";
 import { SelectableComponent } from "../../../../entity/actor/components/selectable-component";
 import { getGameObjectBounds } from "../../../../data/game-object-helper";
 import { IdComponent } from "../../../../entity/actor/components/id-component";
-import { emitEventIssueMoveCommandToSelectedActors, emitEventSelection, getPlayer } from "../../../../data/scene-data";
+import {
+  emitEventIssueActorCommandToSelectedActors,
+  emitEventIssueMoveCommandToSelectedActors,
+  emitEventSelection,
+  getPlayer
+} from "../../../../data/scene-data";
 import { AttackComponent } from "../../../../entity/combat/components/attack-component";
 import { ProductionCostComponent } from "../../../../entity/building/production/production-cost-component";
 import { HealthComponent } from "../../../../entity/combat/components/health-component";
@@ -39,16 +44,22 @@ export class GameObjectSelectionHandler {
             if (this.debug) console.log("singleSelect", data.objectIds);
             const isShiftDown = data.shiftKey;
             const isCtrlDown = data.ctrlKey;
+            const isLeftClick = data.button === "left";
 
-            if (isShiftDown) {
-              if (this.debug) console.log("removeFromSelection", data.objectIds);
-              emitEventSelection(this.scene, "selection.removed", data.objectIds!);
-            } else if (isCtrlDown) {
-              if (this.debug) console.log("additionalSelect", data.objectIds);
-              emitEventSelection(this.scene, "selection.added", data.objectIds!);
+            if (isLeftClick) {
+              if (isShiftDown) {
+                if (this.debug) console.log("removeFromSelection", data.objectIds);
+                emitEventSelection(this.scene, "selection.removed", data.objectIds!);
+              } else if (isCtrlDown) {
+                if (this.debug) console.log("additionalSelect", data.objectIds);
+                emitEventSelection(this.scene, "selection.added", data.objectIds!);
+              } else {
+                emitEventSelection(this.scene, "selection.set", data.objectIds!);
+              }
             } else {
-              emitEventSelection(this.scene, "selection.set", data.objectIds!);
+              emitEventIssueActorCommandToSelectedActors(this.scene, data.objectIds!);
             }
+
             break;
           case "selection.terrainSelect":
             if (this.debug) console.log("terrainSelect", data.terrainSelectedTileVec3, data.terrainSelectedWorldVec3);

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/pawn-ai-controller-component-old.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/pawn-ai-controller-component-old.ts
@@ -76,17 +76,9 @@ export class PawnAiControllerComponentOld {
 
   issueBeginConstructionOrder(constructableBuildingClass: string, targetLocation: Vector3Simple) {
     const orderData: OrderData_old = {
-      orderType: OrderType.BeginConstruction,
+      orderType: OrderType.Build,
       targetLocation,
       args: [constructableBuildingClass] as any
-    };
-    this.issueOrder(orderData);
-  }
-
-  issueContinueConstructionOrder(constructionSite: GameObject) {
-    const orderData: OrderData_old = {
-      orderType: OrderType.ContinueConstruction,
-      targetGameObject: constructionSite
     };
     this.issueOrder(orderData);
   }

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/pawn-ai-controller-component-old.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/pawn-ai-controller-component-old.ts
@@ -1,4 +1,4 @@
-import { OrderData } from "../../../entity/character/ai/order-data";
+import { OrderData_old } from "../../../entity/character/ai/order-data_old";
 import { Queue } from "../../../library/queue";
 import { OrderType } from "../../../entity/character/ai/order-type";
 import { PawnAiBlackboard } from "../../../entity/character/ai/pawn-ai-blackboard";
@@ -10,7 +10,7 @@ import GameObject = Phaser.GameObjects.GameObject;
 
 export class PawnAiControllerComponentOld {
   // declare queue of OrderData
-  orders: Queue<OrderData> = new Queue<OrderData>();
+  orders: Queue<OrderData_old> = new Queue<OrderData_old>();
 
   constructor(
     private readonly gameObject: GameObject,
@@ -30,17 +30,17 @@ export class PawnAiControllerComponentOld {
   findTargetInAcquisitionRadius(): void {}
 
   getCurrentOrder(): OrderType | undefined {
-    return this.blackboard.aiOrderType;
+    return undefined;
   }
 
-  addOrder(order: OrderData): void {
+  addOrder(order: OrderData_old): void {
     if (!order.orderType) {
       return;
     }
     this.orders.enqueueBack(order);
   }
 
-  insertOrder(order: OrderData): void {
+  insertOrder(order: OrderData_old): void {
     this.orders.enqueueBack(order);
 
     this.obtainNextOrder();
@@ -58,7 +58,7 @@ export class PawnAiControllerComponentOld {
     return this.hasOrderByClass(OrderType.Stop);
   }
 
-  issueOrder(orderData: OrderData) {
+  issueOrder(orderData: OrderData_old) {
     console.log("issueOrder", orderData);
     this.orders.empty();
     this.addOrder(orderData);
@@ -66,7 +66,7 @@ export class PawnAiControllerComponentOld {
   }
 
   issueAttackOrder(target: GameObject) {
-    const orderData: OrderData = {
+    const orderData: OrderData_old = {
       orderType: OrderType.Attack,
       targetGameObject: target
     };
@@ -75,7 +75,7 @@ export class PawnAiControllerComponentOld {
   }
 
   issueBeginConstructionOrder(constructableBuildingClass: string, targetLocation: Vector3Simple) {
-    const orderData: OrderData = {
+    const orderData: OrderData_old = {
       orderType: OrderType.BeginConstruction,
       targetLocation,
       args: [constructableBuildingClass] as any
@@ -84,7 +84,7 @@ export class PawnAiControllerComponentOld {
   }
 
   issueContinueConstructionOrder(constructionSite: GameObject) {
-    const orderData: OrderData = {
+    const orderData: OrderData_old = {
       orderType: OrderType.ContinueConstruction,
       targetGameObject: constructionSite
     };
@@ -92,7 +92,7 @@ export class PawnAiControllerComponentOld {
   }
 
   issueGatherOrder(resourceSource: GameObject) {
-    const orderData: OrderData = {
+    const orderData: OrderData_old = {
       orderType: OrderType.Gather,
       targetGameObject: resourceSource
     };
@@ -108,7 +108,7 @@ export class PawnAiControllerComponentOld {
     if (!resourceSource) {
       return false;
     }
-    const orderData: OrderData = {
+    const orderData: OrderData_old = {
       orderType: OrderType.Gather,
       targetGameObject: resourceSource
     };
@@ -118,7 +118,7 @@ export class PawnAiControllerComponentOld {
   }
 
   issueMoveOrder(vector3: Vector3Simple) {
-    const orderData: OrderData = {
+    const orderData: OrderData_old = {
       orderType: OrderType.Move,
       targetLocation: vector3
     };
@@ -142,7 +142,7 @@ export class PawnAiControllerComponentOld {
   }
 
   issueStopOrder() {
-    const orderData: OrderData = {
+    const orderData: OrderData_old = {
       orderType: OrderType.Stop
     };
     this.issueOrder(orderData);
@@ -156,12 +156,12 @@ export class PawnAiControllerComponentOld {
     if (!orderData) {
       return;
     }
-    this.blackboard.aiOrderType = orderData.orderType;
-    this.blackboard.targetGameObject = orderData.targetGameObject;
-    this.blackboard.targetLocation = orderData.targetLocation;
+    // this.blackboard.aiOrderType = orderData.orderType;
+    // this.blackboard.targetGameObject = orderData.targetGameObject;
+    // this.blackboard.targetLocation = orderData.targetLocation;
   }
 
-  private composeReturnResourcesOrder(): OrderData | null {
+  private composeReturnResourcesOrder(): OrderData_old | null {
     const gathererComponent = getActorComponent(this.gameObject, GathererComponent);
     if (!gathererComponent) {
       return null;
@@ -170,7 +170,7 @@ export class PawnAiControllerComponentOld {
     if (!resourceDrain) {
       return null;
     }
-    const orderData: OrderData = {
+    const orderData: OrderData_old = {
       orderType: OrderType.ReturnResources,
       targetGameObject: resourceDrain
     };

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-controller_old.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-controller_old.ts
@@ -1,6 +1,6 @@
 import { RepresentableActor_old } from "../../../entity/actor/representable-actor_old";
 import { Actor } from "../../../entity/actor/actor";
-import { OrderData } from "../../../entity/character/ai/order-data";
+import { OrderData_old } from "../../../entity/character/ai/order-data_old";
 import { GameState_old } from "../game-state/game-state_old";
 import { PlayerState } from "../../../player/player-state";
 
@@ -8,7 +8,7 @@ export class PlayerController_old extends Actor {
   readonly gameState!: GameState_old; // todo
   readonly playerState!: PlayerState; // todo
 
-  issueOrder(orderData: OrderData, issueTo: RepresentableActor_old) {
+  issueOrder(orderData: OrderData_old, issueTo: RepresentableActor_old) {
     throw new Error("Not implemented");
   }
 

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/pawn-ai-controller.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/pawn-ai-controller.ts
@@ -34,12 +34,18 @@ export class PawnAiController {
       case AiType.Character:
         this.agent = new PlayerPawnAiControllerAgent(this.gameObject, this.blackboard);
         this.behaviourTree = new BehaviourTree(PlayerPawnAiControllerMdsl, this.agent);
-        this.blackboard.cancellationHandler = () => (this.agent as PlayerPawnAiControllerAgent).Stop();
+        this.blackboard.cancellationHandler = () => {
+          (this.agent as PlayerPawnAiControllerAgent).Stop();
+          this.behaviourTree.reset();
+        };
         break;
       default:
         this.agent = new PlayerPawnAiControllerAgent(this.gameObject, this.blackboard);
         this.behaviourTree = new BehaviourTree(PlayerPawnAiControllerMdsl, this.agent);
-        this.blackboard.cancellationHandler = () => (this.agent as PlayerPawnAiControllerAgent).Stop();
+        this.blackboard.cancellationHandler = () => {
+          (this.agent as PlayerPawnAiControllerAgent).Stop();
+          this.behaviourTree.reset();
+        };
         break;
     }
 

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/pawn-ai-controller.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/pawn-ai-controller.ts
@@ -18,12 +18,13 @@ export interface PawnAiDefinition {
 }
 
 export class PawnAiController {
-  private readonly blackboard: PawnAiBlackboard = new PawnAiBlackboard();
+  readonly blackboard: PawnAiBlackboard = new PawnAiBlackboard(); // todo it's actually blackboard that should replicate
   private readonly agent: Agent;
   private readonly behaviourTree: BehaviourTree;
   private elapsedTime: number = 0;
   private nodeDebugger?: NodeDebugger;
   private aiDebuggingSubscription?: Subscription;
+  private defaultStepInterval: number = 100;
 
   constructor(
     private readonly gameObject: Phaser.GameObjects.GameObject,
@@ -59,7 +60,7 @@ export class PawnAiController {
 
   private update(_: number, dt: number) {
     this.elapsedTime += dt;
-    if (this.elapsedTime >= (this.pawnAiDefinition.stepInterval ?? 1000)) {
+    if (this.elapsedTime >= (this.pawnAiDefinition.stepInterval ?? this.defaultStepInterval)) {
       try {
         this.behaviourTree.step();
       } catch (e) {
@@ -72,21 +73,16 @@ export class PawnAiController {
 
   private updateDebuggerText() {
     if (!this.nodeDebugger) return;
-    const playerOrderType = this.blackboard.playerOrderType;
+    const playerOrderType = this.blackboard.getCurrentOrder()?.orderType;
     const playerOrderTypeName = playerOrderType !== undefined ? OrderType[playerOrderType] : null;
-    const aiOrderType = this.blackboard.aiOrderType;
-    const aiOrderTypeName = aiOrderType !== undefined ? OrderType[aiOrderType] : null;
-    const targetGameObject = this.blackboard.targetGameObject;
+    const targetGameObject = this.blackboard.getCurrentOrder()?.data.targetGameObject;
     const targetGameObjectName = targetGameObject ? targetGameObject.name : null;
-    const targetLocation = this.blackboard.targetLocation;
+    const targetLocation = this.blackboard.getCurrentOrder()?.data.targetLocation;
     const targetLocationXYZ = targetLocation ? `${targetLocation.x}, ${targetLocation.y}, ${targetLocation.z}` : null;
 
     let text = "";
     if (playerOrderTypeName) {
       text += `Player Order Type: ${playerOrderTypeName}\n`;
-    }
-    if (aiOrderTypeName) {
-      text += `AI Order Type: ${aiOrderTypeName}\n`;
     }
     if (targetGameObjectName) {
       text += `Target Game Object: ${targetGameObjectName}\n`;

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/pawn-ai-controller.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/pawn-ai-controller.ts
@@ -34,10 +34,12 @@ export class PawnAiController {
       case AiType.Character:
         this.agent = new PlayerPawnAiControllerAgent(this.gameObject, this.blackboard);
         this.behaviourTree = new BehaviourTree(PlayerPawnAiControllerMdsl, this.agent);
+        this.blackboard.cancellationHandler = () => (this.agent as PlayerPawnAiControllerAgent).Stop();
         break;
       default:
         this.agent = new PlayerPawnAiControllerAgent(this.gameObject, this.blackboard);
         this.behaviourTree = new BehaviourTree(PlayerPawnAiControllerMdsl, this.agent);
+        this.blackboard.cancellationHandler = () => (this.agent as PlayerPawnAiControllerAgent).Stop();
         break;
     }
 

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/pawn-ai-controller.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/pawn-ai-controller.ts
@@ -11,6 +11,7 @@ import { HealthComponent } from "../../../../entity/combat/components/health-com
 import { getSceneService } from "../../../../scenes/components/scene-component-helpers";
 import { DebuggingService } from "../../../../scenes/services/DebuggingService";
 import { Subscription } from "rxjs";
+import { BehaviourTreeOptions } from "mistreevous/dist/BehaviourTreeOptions";
 
 export interface PawnAiDefinition {
   type: AiType;
@@ -30,10 +31,15 @@ export class PawnAiController {
     private readonly gameObject: Phaser.GameObjects.GameObject,
     private readonly pawnAiDefinition: PawnAiDefinition
   ) {
+    const options = environment.production
+      ? {}
+      : ({
+          //onNodeStateChange: (change: NodeStateChange) => console.log(change)
+        } satisfies BehaviourTreeOptions);
     switch (pawnAiDefinition.type) {
       case AiType.Character:
         this.agent = new PlayerPawnAiControllerAgent(this.gameObject, this.blackboard);
-        this.behaviourTree = new BehaviourTree(PlayerPawnAiControllerMdsl, this.agent);
+        this.behaviourTree = new BehaviourTree(PlayerPawnAiControllerMdsl, this.agent, options);
         this.blackboard.cancellationHandler = () => {
           (this.agent as PlayerPawnAiControllerAgent).Stop();
           this.behaviourTree.reset();
@@ -41,7 +47,7 @@ export class PawnAiController {
         break;
       default:
         this.agent = new PlayerPawnAiControllerAgent(this.gameObject, this.blackboard);
-        this.behaviourTree = new BehaviourTree(PlayerPawnAiControllerMdsl, this.agent);
+        this.behaviourTree = new BehaviourTree(PlayerPawnAiControllerMdsl, this.agent, options);
         this.blackboard.cancellationHandler = () => {
           (this.agent as PlayerPawnAiControllerAgent).Stop();
           this.behaviourTree.reset();

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
@@ -44,7 +44,7 @@ export interface IPlayerPawnControllerAgent {
   Stop(): State;
   AssignMoveRandomlyInRange(range: number): Promise<State>;
   TargetExists(): boolean;
-  ReachedLocation(): boolean;
+  TargetOrLocationExists(): boolean;
 
   // Utility
   Succeed(): State;

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
@@ -43,6 +43,7 @@ export interface IPlayerPawnControllerAgent {
   Stop(): State;
   AssignMoveRandomlyInRange(range: number): Promise<State>;
   TargetExists(): boolean;
+  ReachedLocation(): boolean;
 
   // Utility
   Succeed(): State;

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
@@ -41,6 +41,8 @@ export interface IPlayerPawnControllerAgent {
 
   // Construction and Building
   ConstructBuilding(): State;
+  CanAssignBuilder(): boolean;
+  HasBuilderComponent(): boolean;
   LeaveConstructionSiteOrCurrentContainer(): State;
 
   // Movement

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
@@ -25,7 +25,11 @@ export interface IPlayerPawnControllerAgent {
   AnyEnemyVisible(): boolean;
   CooldownReady(type: PlayerPawnCooldownType): boolean;
   Attacked(): boolean;
+
+  // Healing
   Heal(): State;
+  CanHeal(): boolean;
+  HasHealerComponent(): boolean;
 
   // Resource Gathering
   AcquireNewResourceSource(): State;

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
@@ -1,5 +1,8 @@
 import { State } from "mistreevous";
 
+export type PlayerPawnRangeType = "move" | "gather" | "attack" | "dropOff" | "construct" | "heal";
+export type PlayerPawnCooldownType = "gather" | "attack" | "construct" | "heal";
+
 export interface IPlayerPawnControllerAgent {
   // Player Orders and Status
   OrderExistsInQueue(): boolean;
@@ -9,13 +12,12 @@ export interface IPlayerPawnControllerAgent {
   // Combat-related Actions
   HasAttackComponent(): boolean;
   TargetIsAlive(): boolean;
-  HealthAboveThresholdPercentage(threshold: number): boolean;
-  InRange(type: "gather" | "attack" | "dropOff" | "construct"): boolean;
+  InRange(type: PlayerPawnRangeType): boolean;
   Attack(): State;
   AssignEnemy(source: string): State;
   NoEnemiesVisible(): boolean;
   AnyEnemyVisible(): boolean;
-  CooldownReady(type: string): boolean;
+  CooldownReady(type: PlayerPawnCooldownType): boolean;
   Attacked(): boolean;
   Heal(): State;
 
@@ -29,15 +31,14 @@ export interface IPlayerPawnControllerAgent {
   GatherHighValueResource(): State;
   HasHarvestComponent(): boolean;
   GatherCapacityFull(): boolean;
-  AssignResourceDropOff(): State;
 
   // Construction and Building
   ConstructBuilding(): State;
   LeaveConstructionSiteOrCurrentContainer(): State;
 
   // Movement
-  MoveToTarget(type: "move" | "gather" | "attack" | "dropOff" | "construct"): Promise<State>;
-  MoveToTargetOrLocation(type: "move" | "gather" | "attack" | "dropOff" | "construct"): Promise<State>;
+  MoveToTarget(type: PlayerPawnRangeType): Promise<State>;
+  MoveToTargetOrLocation(type: PlayerPawnRangeType): Promise<State>;
   MoveToLocation(): Promise<State>;
   Stop(): State;
   AssignMoveRandomlyInRange(range: number): Promise<State>;

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
@@ -17,6 +17,7 @@ export interface IPlayerPawnControllerAgent {
   AnyEnemyVisible(): boolean;
   CooldownReady(type: string): boolean;
   Attacked(): boolean;
+  Heal(): State;
 
   // Resource Gathering
   AcquireNewResourceSource(): State;

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
@@ -9,13 +9,18 @@ export interface IPlayerPawnControllerAgent {
   AssignNextOrderFromQueue(): State;
   PlayerOrderIs(orderType: string): boolean;
 
+  // Assign orders
+  AssignDropOffResourcesOrder(): State;
+  AssignGatherResourcesOrder(): State;
+  AssignEnemy(source: string): State;
+  AssignMoveRandomlyInRange(range: number): Promise<State>;
+
   // Combat-related Actions
   HasAttackComponent(): boolean;
   TargetIsAlive(): boolean;
   /* InRange is not condition but promisey action until this is addressed - https://github.com/nikkorn/mistreevous/issues/95 */
   InRange(type: PlayerPawnRangeType): Promise<State>;
   Attack(): State;
-  AssignEnemy(source: string): State;
   NoEnemiesVisible(): boolean;
   AnyEnemyVisible(): boolean;
   CooldownReady(type: PlayerPawnCooldownType): boolean;
@@ -24,6 +29,7 @@ export interface IPlayerPawnControllerAgent {
 
   // Resource Gathering
   AcquireNewResourceSource(): State;
+  AcquireNewResourceDrain(): State;
   GatherResource(): Promise<State>;
   DropOffResources(): Promise<State>;
   ContinueGathering(): State;
@@ -42,7 +48,6 @@ export interface IPlayerPawnControllerAgent {
   MoveToTargetOrLocation(type: PlayerPawnRangeType): Promise<State>;
   MoveToLocation(): Promise<State>;
   Stop(): State;
-  AssignMoveRandomlyInRange(range: number): Promise<State>;
   TargetExists(): boolean;
   TargetOrLocationExists(): boolean;
 

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
@@ -2,7 +2,8 @@ import { State } from "mistreevous";
 
 export interface IPlayerPawnControllerAgent {
   // Player Orders and Status
-  PlayerOrderExists(): boolean;
+  OrderExistsInQueue(): boolean;
+  AssignNextOrderFromQueue(): State;
   PlayerOrderIs(orderType: string): boolean;
 
   // Combat-related Actions
@@ -35,7 +36,13 @@ export interface IPlayerPawnControllerAgent {
 
   // Movement
   MoveToTarget(type: "move" | "gather" | "attack" | "dropOff" | "construct"): Promise<State>;
+  MoveToTargetOrLocation(type: "move" | "gather" | "attack" | "dropOff" | "construct"): Promise<State>;
+  MoveToLocation(): Promise<State>;
   Stop(): State;
-  MoveRandomlyInRange(range: number): Promise<State>;
+  AssignMoveRandomlyInRange(range: number): Promise<State>;
   TargetExists(): boolean;
+
+  // Utility
+  Succeed(): State;
+  Fail(): State;
 }

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
@@ -12,7 +12,8 @@ export interface IPlayerPawnControllerAgent {
   // Combat-related Actions
   HasAttackComponent(): boolean;
   TargetIsAlive(): boolean;
-  InRange(type: PlayerPawnRangeType): boolean;
+  /* InRange is not condition but promisey action until this is addressed - https://github.com/nikkorn/mistreevous/issues/95 */
+  InRange(type: PlayerPawnRangeType): Promise<State>;
   Attack(): State;
   AssignEnemy(source: string): State;
   NoEnemiesVisible(): boolean;
@@ -48,4 +49,5 @@ export interface IPlayerPawnControllerAgent {
   // Utility
   Succeed(): State;
   Fail(): State;
+  Log(message: string): State;
 }

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.interface.ts
@@ -1,7 +1,7 @@
 import { State } from "mistreevous";
 
-export type PlayerPawnRangeType = "move" | "gather" | "attack" | "dropOff" | "construct" | "heal";
-export type PlayerPawnCooldownType = "gather" | "attack" | "construct" | "heal";
+export type PlayerPawnRangeType = "move" | "gather" | "attack" | "dropOff" | "construct" | "heal" | "repair";
+export type PlayerPawnCooldownType = "gather" | "attack" | "construct" | "heal" | "repair";
 
 export interface IPlayerPawnControllerAgent {
   // Player Orders and Status
@@ -44,6 +44,12 @@ export interface IPlayerPawnControllerAgent {
   CanAssignBuilder(): boolean;
   HasBuilderComponent(): boolean;
   LeaveConstructionSiteOrCurrentContainer(): State;
+
+  // Repair
+  ConstructionSiteFinished(): boolean;
+  TargetHealthFull(): boolean;
+  RepairBuilding(): State;
+  CanAssignRepairer(): boolean;
 
   // Movement
   MoveToTarget(type: PlayerPawnRangeType): Promise<State>;

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
@@ -239,7 +239,20 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent, 
       resourceSource = gathererComponent.getNewResourceSource();
     }
     if (!resourceSource) return State.FAILED;
-    this.blackboard.addOrder(new OrderData(OrderType.Gather, { targetGameObject: resourceSource }));
+    const currentOrder = this.blackboard.getCurrentOrder();
+    if (!currentOrder) return State.FAILED;
+    currentOrder.data.targetGameObject = resourceSource;
+    return State.SUCCEEDED;
+  }
+
+  AcquireNewResourceDrain() {
+    const gathererComponent = getActorComponent(this.gameObject, GathererComponent);
+    if (!gathererComponent) return State.FAILED;
+    const resourceDrain = gathererComponent.getPreferredResourceDrain();
+    if (!resourceDrain) return State.FAILED;
+    const currentOrder = this.blackboard.getCurrentOrder();
+    if (!currentOrder) return State.FAILED;
+    currentOrder.data.targetGameObject = resourceDrain;
     return State.SUCCEEDED;
   }
 
@@ -427,6 +440,36 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent, 
     const gathererComponent = getActorComponent(this.gameObject, GathererComponent);
     if (!gathererComponent) return false;
     return gathererComponent.isCapacityFull();
+  }
+
+  AssignDropOffResourcesOrder(): State {
+    const currentOrder = this.blackboard.getCurrentOrder();
+    if (!currentOrder) return State.FAILED;
+
+    const gathererComponent = getActorComponent(this.gameObject, GathererComponent);
+    if (!gathererComponent) return State.FAILED;
+
+    const preferredResourceDrain = gathererComponent.getPreferredResourceDrain();
+    if (!preferredResourceDrain) return State.FAILED;
+
+    currentOrder.orderType = OrderType.ReturnResources;
+    currentOrder.data.targetGameObject = preferredResourceDrain;
+    return State.SUCCEEDED;
+  }
+
+  AssignGatherResourcesOrder(): State {
+    const currentOrder = this.blackboard.getCurrentOrder();
+    if (!currentOrder) return State.FAILED;
+
+    const gathererComponent = getActorComponent(this.gameObject, GathererComponent);
+    if (!gathererComponent) return State.FAILED;
+
+    const preferredResourceSource = gathererComponent.getPreferredResourceSource();
+    if (!preferredResourceSource) return State.FAILED;
+
+    currentOrder.orderType = OrderType.Gather;
+    currentOrder.data.targetGameObject = preferredResourceSource;
+    return State.SUCCEEDED;
   }
 
   Succeed() {

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
@@ -176,7 +176,10 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent, 
           movementSystem.cancelMovement();
         }
       }
+      this.blackboard.resetCurrentOrder(false);
     }
+
+    this.blackboard.popCurrentOrderFromQueue();
     return State.SUCCEEDED;
   };
 

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
@@ -157,6 +157,16 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent, 
     }
   }
 
+  ReachedLocation() {
+    const currentOrder = this.blackboard.getCurrentOrder();
+    if (!currentOrder) return false;
+    const location = currentOrder.data.targetLocation;
+    if (!location) return false;
+    const distance = GameplayLibrary.getTileDistanceBetweenGameObjectAndTile(this.gameObject, location);
+    if (distance === null) return false;
+    return distance <= 0;
+  }
+
   Stop = () => {
     const currentOrder = this.blackboard.getCurrentOrder();
     if (currentOrder) {

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
@@ -356,10 +356,23 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent, 
     if (!currentOrder) return State.FAILED;
     const target = currentOrder.data.targetGameObject;
     if (!target) return State.FAILED;
-    const healingComponent = getActorComponent(target, HealingComponent);
+    const healingComponent = getActorComponent(this.gameObject, HealingComponent);
     if (!healingComponent) return State.FAILED;
     healingComponent.heal(target);
     return State.SUCCEEDED;
+  }
+
+  CanHeal(): boolean {
+    const currentOrder = this.blackboard.getCurrentOrder();
+    if (!currentOrder) return false;
+    const target = currentOrder.data.targetGameObject;
+    if (!target) return false;
+    const healthComponent = getActorComponent(target, HealthComponent);
+    if (!healthComponent) return false;
+    return !healthComponent.healthIsFull;
+  }
+  HasHealerComponent(): boolean {
+    return !!getActorComponent(this.gameObject, HealingComponent);
   }
 
   AssignEnemy(source: string): State {

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
@@ -158,10 +158,18 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent, 
     }
   }
 
-  Stop() {
-    this.blackboard.resetAll();
+  Stop = () => {
+    const currentOrder = this.blackboard.getCurrentOrder();
+    if (currentOrder) {
+      if (currentOrder.orderType === OrderType.Move) {
+        const movementSystem = getActorSystem(this.gameObject, MovementSystem);
+        if (movementSystem) {
+          movementSystem.cancelMovement();
+        }
+      }
+    }
     return State.SUCCEEDED;
-  }
+  };
 
   Attack() {
     const currentOrder = this.blackboard.getCurrentOrder();

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
@@ -21,6 +21,7 @@ import { ContainableComponent } from "../../../../entity/actor/components/contai
 import { ResourceDrainComponent } from "../../../../entity/economy/resource/resource-drain-component";
 import { BuilderComponent } from "../../../../entity/actor/components/builder-component";
 import { OrderData } from "../../../../entity/character/ai/OrderData";
+import { HealingComponent } from "../../../../entity/combat/components/healing-component";
 
 export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent, Agent {
   constructor(
@@ -282,6 +283,17 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent, 
     // noinspection UnnecessaryLocalVariableJS
     const attacked = (healthComponent.latestDamage?.timestamp.getTime() ?? 0) > new Date().getTime() - attackedCooldown;
     return attacked;
+  }
+
+  Heal(): State {
+    const currentOrder = this.blackboard.getCurrentOrder();
+    if (!currentOrder) return State.FAILED;
+    const target = currentOrder.data.targetGameObject;
+    if (!target) return State.FAILED;
+    const healingComponent = getActorComponent(target, HealingComponent);
+    if (!healingComponent) return State.FAILED;
+    healingComponent.heal(target);
+    return State.SUCCEEDED;
   }
 
   AssignEnemy(source: string): State {

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
@@ -40,7 +40,7 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent, 
   }
 
   AssignNextOrderFromQueue() {
-    const playerOrder = this.blackboard.pullNextPlayerOrder();
+    const playerOrder = this.blackboard.peekNextPlayerOrder();
     if (!playerOrder) return State.FAILED;
     this.blackboard.setCurrentOrder(playerOrder);
     return State.SUCCEEDED;

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
@@ -181,6 +181,7 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent, 
       return success ? State.SUCCEEDED : State.FAILED;
     } catch (e) {
       console.error("Error in MoveToLocation", e);
+      this.Stop();
       return State.FAILED;
     }
   }

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
@@ -220,4 +220,18 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
   Log() {
     return State.SUCCEEDED;
   }
+
+  ConstructionSiteFinished() {
+    return getBooleanValue("Is the construction site fully built?");
+  }
+  TargetHealthFull() {
+    return getBooleanValue("Is the target health full?");
+  }
+  RepairBuilding() {
+    showInfoToast("Repairing building!");
+    return State.SUCCEEDED;
+  }
+  CanAssignRepairer() {
+    return getBooleanValue("Can the agent be assigned as a repairer?");
+  }
 }

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
@@ -122,6 +122,16 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
     return State.SUCCEEDED;
   }
 
+  CanAssignBuilder() {
+    // Check if the agent can be assigned as a builder
+    return getBooleanValue("Can the agent be assigned as a builder?");
+  }
+
+  HasBuilderComponent() {
+    // Check if the agent has the capability to build
+    return getBooleanValue("Does the agent have a builder component?");
+  }
+
   Attacked() {
     // Check if the agent has been attacked
     return getBooleanValue("Has the agent been attacked?");

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
@@ -3,7 +3,6 @@ import { IPlayerPawnControllerAgent } from "./player-pawn-ai-controller.agent.in
 import {
   getBooleanValue,
   getNumberValue,
-  getStringValue,
   showInfoToast
 } from "../behavior-tree-utilities/behavior-tree-global-functions";
 
@@ -11,15 +10,21 @@ import {
  * https://nikkorn.github.io/mistreevous-visualiser/index.html
  */
 class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgent {
-  PlayerOrderExists() {
-    // Check if there's an order assigned to the player
-    return getBooleanValue("Is there a player order?");
+  orderQueue = [];
+  currentOrder = null;
+  OrderExistsInQueue() {
+    return !!this.orderQueue.length;
+  }
+
+  AssignNextOrderFromQueue() {
+    // @ts-expect-error - unused parameter.
+    this.currentOrder = this.orderQueue.shift();
+    return State.SUCCEEDED;
   }
 
   // @ts-expect-error - unused parameter.
   PlayerOrderIs(orderType) {
-    // Check if the current player order matches the specified order type
-    return getStringValue("What is the current player order?") === orderType;
+    return this.currentOrder?.["orderType"] === orderType;
   }
 
   HasAttackComponent() {
@@ -49,6 +54,18 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
     return Promise.resolve(State.SUCCEEDED);
   }
 
+  MoveToTargetOrLocation() {
+    // Command the agent to move to the target or a specific location
+    showInfoToast("Moving to target or location!");
+    return Promise.resolve(State.SUCCEEDED);
+  }
+
+  MoveToLocation() {
+    // Command the agent to move to a specific location
+    showInfoToast("Moving to location!");
+    return Promise.resolve(State.SUCCEEDED);
+  }
+
   Stop() {
     // Command the agent to stop its current action
     showInfoToast("Agent stopped.");
@@ -68,13 +85,17 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
 
   AcquireNewResourceSource() {
     // Find a new resource to gather from
-    showInfoToast("Acquiring new resource source!");
+    showInfoToast("Acquiring new resource source.");
+    // @ts-expect-error - unused parameter.
+    this.orderQueue.push({ orderType: "gather", target: "resource" });
     return State.SUCCEEDED;
   }
 
   AssignResourceDropOff() {
     // Assign a drop-off point for resources
     showInfoToast("Assigning resource drop-off.");
+    // @ts-expect-error - unused parameter.
+    this.orderQueue.push({ orderType: "dropOff", target: "dropOff" });
     return State.SUCCEEDED;
   }
 
@@ -116,13 +137,17 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
   AssignEnemy() {
     // Assign an enemy to the agent
     showInfoToast("Assigning enemy.");
+    // @ts-expect-error - unused parameter.
+    this.orderQueue.push({ orderType: "attack", target: "enemy" });
     return State.SUCCEEDED;
   }
 
   // @ts-expect-error - unused parameter.
-  MoveRandomlyInRange(range) {
+  AssignMoveRandomlyInRange(range) {
     // Command the agent to move randomly within the specified range
     showInfoToast(`Moving randomly within range: ${range}`);
+    // @ts-expect-error - unused parameter.
+    this.orderQueue.push({ orderType: "move", target: "random" });
     return Promise.resolve(State.SUCCEEDED);
   }
 
@@ -164,5 +189,12 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
 
   GatherCapacityFull() {
     return getBooleanValue("Is the agent gathering capacity full?");
+  }
+
+  Succeed() {
+    return State.SUCCEEDED;
+  }
+  Fail() {
+    return State.FAILED;
   }
 }

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
@@ -83,8 +83,12 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
   AcquireNewResourceSource() {
     // Find a new resource to gather from
     showInfoToast("Acquiring new resource source.");
-    // @ts-expect-error - unused parameter.
-    this.orderQueue.push({ orderType: "gather", target: "resource" });
+    return State.SUCCEEDED;
+  }
+
+  AcquireNewResourceDrain() {
+    // Find a new resource to drop off resources at
+    showInfoToast("Acquiring new resource drain.");
     return State.SUCCEEDED;
   }
 
@@ -183,6 +187,16 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
 
   GatherCapacityFull() {
     return getBooleanValue("Is the agent gathering capacity full?");
+  }
+
+  AssignDropOffResourcesOrder() {
+    showInfoToast("Assigning drop-off resources order.");
+    return State.SUCCEEDED;
+  }
+
+  AssignGatherResourcesOrder() {
+    showInfoToast("Assigning gather resources order.");
+    return State.SUCCEEDED;
   }
 
   Succeed() {

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
@@ -35,7 +35,7 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
 
   InRange() {
     // Check if the agent is within range of the target
-    return getBooleanValue("Is the agent in range of the target?");
+    return Promise.resolve(State.SUCCEEDED);
   }
 
   MoveToTarget() {
@@ -189,5 +189,8 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
   }
   Fail() {
     return State.FAILED;
+  }
+  Log() {
+    return State.SUCCEEDED;
   }
 }

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
@@ -66,6 +66,12 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
     return Promise.resolve(State.SUCCEEDED);
   }
 
+  Heal() {
+    // Command the agent to heal the target
+    showInfoToast("Healing the target!");
+    return State.SUCCEEDED;
+  }
+
   Stop() {
     // Command the agent to stop its current action
     showInfoToast("Agent stopped.");

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
@@ -1,10 +1,6 @@
 import { State } from "mistreevous";
 import { IPlayerPawnControllerAgent } from "./player-pawn-ai-controller.agent.interface";
-import {
-  getBooleanValue,
-  getNumberValue,
-  showInfoToast
-} from "../behavior-tree-utilities/behavior-tree-global-functions";
+import { getBooleanValue, showInfoToast } from "../behavior-tree-utilities/behavior-tree-global-functions";
 
 /**
  * https://nikkorn.github.io/mistreevous-visualiser/index.html
@@ -35,12 +31,6 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
   TargetIsAlive() {
     // Check if the target is still alive
     return getBooleanValue("Is the target alive?");
-  }
-
-  // @ts-expect-error - unused parameter.
-  HealthAboveThresholdPercentage(threshold) {
-    // Check if the agent's health is above a certain threshold
-    return getNumberValue("What is the agent's current health?") > threshold;
   }
 
   InRange() {
@@ -94,14 +84,6 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
     showInfoToast("Acquiring new resource source.");
     // @ts-expect-error - unused parameter.
     this.orderQueue.push({ orderType: "gather", target: "resource" });
-    return State.SUCCEEDED;
-  }
-
-  AssignResourceDropOff() {
-    // Assign a drop-off point for resources
-    showInfoToast("Assigning resource drop-off.");
-    // @ts-expect-error - unused parameter.
-    this.orderQueue.push({ orderType: "dropOff", target: "dropOff" });
     return State.SUCCEEDED;
   }
 

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
@@ -8,6 +8,7 @@ import { getBooleanValue, showInfoToast } from "../behavior-tree-utilities/behav
 class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgent {
   orderQueue = [];
   currentOrder = null;
+
   OrderExistsInQueue() {
     return !!this.orderQueue.length;
   }
@@ -54,11 +55,6 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
     // Command the agent to move to a specific location
     showInfoToast("Moving to location!");
     return Promise.resolve(State.SUCCEEDED);
-  }
-
-  ReachedLocation() {
-    // Check if the agent has reached the target location
-    return getBooleanValue("Has the agent reached the target location?");
   }
 
   Heal() {
@@ -154,6 +150,11 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
     return getBooleanValue("Does the target exist?");
   }
 
+  TargetOrLocationExists() {
+    // Check if the target or location exists
+    return getBooleanValue("Does the target or location exist?");
+  }
+
   TargetHasResources() {
     // Check if the target still has resources to gather
     return getBooleanValue("Does the target have resources?");
@@ -187,9 +188,11 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
   Succeed() {
     return State.SUCCEEDED;
   }
+
   Fail() {
     return State.FAILED;
   }
+
   Log() {
     return State.SUCCEEDED;
   }

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
@@ -56,6 +56,11 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
     return Promise.resolve(State.SUCCEEDED);
   }
 
+  ReachedLocation() {
+    // Check if the agent has reached the target location
+    return getBooleanValue("Has the agent reached the target location?");
+  }
+
   Heal() {
     // Command the agent to heal the target
     showInfoToast("Healing the target!");

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
@@ -63,6 +63,16 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
     return State.SUCCEEDED;
   }
 
+  CanHeal() {
+    // Check if the agent can heal
+    return getBooleanValue("Can the agent heal?");
+  }
+
+  HasHealerComponent() {
+    // Check if the agent has the capability to heal
+    return getBooleanValue("Does the agent have a healer component?");
+  }
+
   Stop() {
     // Command the agent to stop its current action
     showInfoToast("Agent stopped.");

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.visualizer.ts
@@ -16,7 +16,8 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
     return getBooleanValue("Is there a player order?");
   }
 
-  PlayerOrderIs(orderType: string): boolean {
+  // @ts-expect-error - unused parameter.
+  PlayerOrderIs(orderType) {
     // Check if the current player order matches the specified order type
     return getStringValue("What is the current player order?") === orderType;
   }
@@ -31,7 +32,8 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
     return getBooleanValue("Is the target alive?");
   }
 
-  HealthAboveThresholdPercentage(threshold: number): boolean {
+  // @ts-expect-error - unused parameter.
+  HealthAboveThresholdPercentage(threshold) {
     // Check if the agent's health is above a certain threshold
     return getNumberValue("What is the agent's current health?") > threshold;
   }
@@ -41,7 +43,7 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
     return getBooleanValue("Is the agent in range of the target?");
   }
 
-  MoveToTarget(): Promise<State> {
+  MoveToTarget() {
     // Command the agent to move to the target
     showInfoToast("Moving to target!");
     return Promise.resolve(State.SUCCEEDED);
@@ -79,10 +81,10 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
   GatherResource() {
     // Command the agent to gather resources
     showInfoToast("Gathering resources!");
-    return State.SUCCEEDED;
+    return Promise.resolve(State.SUCCEEDED);
   }
 
-  DropOffResources(): Promise<State> {
+  DropOffResources() {
     // Command the agent to return gathered resources to the drop-off point
     showInfoToast("Returning resources to drop-off.");
     return Promise.resolve(State.SUCCEEDED);
@@ -111,13 +113,14 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
     return getBooleanValue("Has the agent been attacked?");
   }
 
-  AssignEnemy(): State {
+  AssignEnemy() {
     // Assign an enemy to the agent
     showInfoToast("Assigning enemy.");
     return State.SUCCEEDED;
   }
 
-  MoveRandomlyInRange(range: number): Promise<State> {
+  // @ts-expect-error - unused parameter.
+  MoveRandomlyInRange(range) {
     // Command the agent to move randomly within the specified range
     showInfoToast(`Moving randomly within range: ${range}`);
     return Promise.resolve(State.SUCCEEDED);
@@ -159,7 +162,7 @@ class PlayerPawnAiControllerAgentVisualizer implements IPlayerPawnControllerAgen
     return getBooleanValue("Does the agent have a harvest component?");
   }
 
-  GatherCapacityFull(): boolean {
+  GatherCapacityFull() {
     return getBooleanValue("Is the agent gathering capacity full?");
   }
 }

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.mdsl.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.mdsl.ts
@@ -23,9 +23,11 @@
 export const PlayerPawnAiControllerMdsl = `
 root {
     selector {
-        sequence {
-            condition [OrderExistsInQueue]
-            action [AssignNextOrderFromQueue]
+        fail {
+            sequence {
+                condition [OrderExistsInQueue]
+                action [AssignNextOrderFromQueue]
+            }
         }
         branch [ExecuteCurrentOrder]
         branch [AutoAssignNewOrder]

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.mdsl.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.mdsl.ts
@@ -38,7 +38,7 @@ root [ExecuteCurrentOrder] {
             condition [HasAttackComponent]
             condition [TargetExists]
             condition [TargetIsAlive]
-            branch [ExecuteAttackOrder]
+            branch [AttackMoveEnemyTarget]
         }
         sequence {
             condition [PlayerOrderIs, "move"]
@@ -98,24 +98,6 @@ root [AutoAssignNewOrder] {
     }
 }
 
-root [ExecuteAttackOrder] {
-    succeed {
-        sequence {
-            action [LeaveConstructionSiteOrCurrentContainer]
-            selector {
-                sequence {
-                    flip {
-                        condition [PlayerOrderIs, "attack"]
-                    }
-                    condition [HealthAboveThresholdPercentage, 20]
-                    branch [AttackMoveEnemyTarget]
-                }
-            }
-            branch [AttackMoveEnemyTarget]
-        }
-    }
-}
-
 root [AttackMoveEnemyTarget] {
   selector {
       sequence {
@@ -162,7 +144,6 @@ root [GatherResource] {
 root [ReturnResources] {
     sequence {
         action [LeaveConstructionSiteOrCurrentContainer]
-        action [AssignResourceDropOff]
         selector {
             sequence {
               flip {
@@ -197,7 +178,10 @@ root [ConstructBuilding] {
                     action [MoveToTarget, "construct"]
                 }
             }
-            action [ConstructBuilding]
+            sequence {
+                condition [CooldownReady, "construct"]
+                action [ConstructBuilding]
+            }
         }
     }
 }
@@ -217,7 +201,10 @@ root [Heal] {
                     action [MoveToTarget, "heal"]
                 }
             }
-            action [Heal]
+            sequence {
+                condition [CooldownReady, "heal"]
+                action [Heal]
+            }
         }
     }
 }

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.mdsl.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.mdsl.ts
@@ -480,7 +480,7 @@ root [Heal] {
                 /* if healer cannot be assigned, stop */
                 sequence {
                     flip {
-                        condition [CanAssignHealer]
+                        condition [CanHeal]
                     }
                     action [Stop]
                 }
@@ -512,7 +512,7 @@ root [Heal] {
                 }
 
                 /* cooldown ready, heal */
-                action [HealBuilding]
+                action [Heal]
             }
         }
     }

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.mdsl.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.mdsl.ts
@@ -30,7 +30,7 @@ root {
             }
         }
         branch [ExecuteCurrentOrder]
-        /* branch [AutoAssignNewOrder] */
+        branch [AutoAssignNewOrder]
     }
 }
 
@@ -49,6 +49,8 @@ root [ExecuteCurrentOrder] {
 
 root [AutoAssignNewOrder] {
     selector {
+
+        /* Retaliation */
         sequence {
             condition [Attacked]
             condition [HasAttackComponent]
@@ -57,6 +59,8 @@ root [AutoAssignNewOrder] {
             }
             action [AssignEnemy, "retaliation"]
         }
+
+        /* Attacking visible enemies */
         sequence {
             condition [AnyEnemyVisible]
             condition [HasAttackComponent]
@@ -65,8 +69,13 @@ root [AutoAssignNewOrder] {
             }
             action [AssignEnemy, "vision"]
         }
+
+        /* Moving randomly */
         sequence {
-          action [AssignMoveRandomlyInRange, 5]
+            action [AssignMoveRandomlyInRange, 1]
+            sequence {
+                wait [2000, 5000]
+            }
         }
     }
 }

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.mdsl.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.mdsl.ts
@@ -2,14 +2,15 @@ export const PlayerPawnAiControllerMdsl = `
 root {
     selector {
         sequence {
-            condition [PlayerOrderExists]
-            branch [PlayerOrder]
+            condition [OrderExistsInQueue]
+            action [AssignNextOrderFromQueue]
         }
-        branch [AiOrder]
+        branch [ExecuteCurrentOrder]
+        branch [AutoAssignNewOrder]
     }
 }
 
-root [PlayerOrder] {
+root [ExecuteCurrentOrder] {
     selector {
         sequence {
             condition [PlayerOrderIs, "attack"]
@@ -20,7 +21,7 @@ root [PlayerOrder] {
         }
         sequence {
             condition [PlayerOrderIs, "move"]
-            action [MoveToTarget, "move"]
+            action [MoveToTargetOrLocation, "move"]
         }
         sequence {
             condition [PlayerOrderIs, "stop"]
@@ -48,13 +49,12 @@ root [PlayerOrder] {
     }
 }
 
-root [AiOrder] {
+root [AutoAssignNewOrder] {
     selector {
         sequence {
             condition [Attacked]
             condition [HasAttackComponent]
             action [AssignEnemy, "retaliation"]
-            branch [ExecuteAttackOrder]
         }
         sequence {
             condition [AnyEnemyVisible]
@@ -63,15 +63,9 @@ root [AiOrder] {
                 condition [HasHarvestComponent]
             }
             action [AssignEnemy, "vision"]
-            branch [ExecuteAttackOrder]
         }
         sequence {
-            condition [HasHarvestComponent]
-            branch [AiOrderGatherAndReturnResources]
-        }
-        sequence {
-          action [MoveRandomlyInRange, 5]
-          wait [2000]
+          action [AssignMoveRandomlyInRange, 5]
         }
     }
 }
@@ -134,16 +128,6 @@ root [GatherResource] {
             condition [CooldownReady, "gather"]
             action [GatherResource]
         }
-    }
-}
-
-root [AiOrderGatherAndReturnResources] {
-    selector {
-        sequence {
-            condition [GatherCapacityFull]
-            branch [ReturnResources]
-        }
-        branch [GatherResource]
     }
 }
 

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.mdsl.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.mdsl.ts
@@ -45,7 +45,13 @@ root [ExecuteCurrentOrder] {
         }
         sequence {
             condition [PlayerOrderIs, "move"]
-            action [MoveToTargetOrLocation, "move"]
+            selector {
+                sequence {
+                    condition [ReachedLocation]
+                    action [Stop]
+                }
+                action [MoveToTargetOrLocation, "move"]
+            }
         }
         sequence {
             condition [PlayerOrderIs, "stop"]

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.mdsl.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.mdsl.ts
@@ -1,4 +1,5 @@
 /**
+ * sequence - runs children until first FAILURE or all SUCCESS
  * selector - finishes when first child returns SUCCESS
  * parallel - runs multiple until all SUCCESS or any FAILURE
  * race - runs multiple until any SUCCESS or all FAILURE

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.mdsl.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.mdsl.ts
@@ -1,3 +1,24 @@
+/**
+ * selector - finishes when first child returns SUCCESS
+ * parallel - runs multiple until all SUCCESS or any FAILURE
+ * race - runs multiple until any SUCCESS or all FAILURE
+ * all - runs multiple until all finish
+ * lotto - selects one child to run
+ * repeat - runs N times or until child returns FAILURE
+ * retry - runs N times if child returns FAILURE, if child returns SUCCESS, returns SUCCESS
+ * flip - returns SUCCESS if child returns FAILURE, returns FAILURE if child returns SUCCESS
+ * succeed - returns SUCCESS
+ * fail - returns FAILURE
+ * action - runs a function
+ * condition - checks a condition
+ * wait - waits for N seconds
+ * branch - runs another tree
+ * callbacks - entry, step, exit functions
+ * guards - removes node from running state if condition is false - useful with wait
+ *   while - if condition is true
+ *   until - if condition is false
+ * */
+
 export const PlayerPawnAiControllerMdsl = `
 root {
     selector {
@@ -39,12 +60,16 @@ root [ExecuteCurrentOrder] {
             branch [ReturnResources]
         }
         sequence {
-            condition [PlayerOrderIs, "beginConstruction"]
+            condition [PlayerOrderIs, "build"]
             branch [ConstructBuilding]
         }
         sequence {
-            condition [PlayerOrderIs, "continueConstruction"]
+            condition [PlayerOrderIs, "repair"]
             branch [ConstructBuilding]
+        }
+        sequence {
+            condition [PlayerOrderIs, "heal"]
+            branch [Heal]
         }
     }
 }
@@ -54,6 +79,9 @@ root [AutoAssignNewOrder] {
         sequence {
             condition [Attacked]
             condition [HasAttackComponent]
+            flip {
+                condition [HasHarvestComponent]
+            }
             action [AssignEnemy, "retaliation"]
         }
         sequence {
@@ -170,6 +198,26 @@ root [ConstructBuilding] {
                 }
             }
             action [ConstructBuilding]
+        }
+    }
+}
+
+root [Heal] {
+    sequence {
+        action [LeaveConstructionSiteOrCurrentContainer]
+        parallel {
+            selector {
+                flip {
+                    condition [TargetIsAlive]
+                }
+                action [Stop]
+                action [LeaveConstructionSiteOrCurrentContainer]
+                sequence {
+                    condition [InRange, "heal"]
+                    action [MoveToTarget, "heal"]
+                }
+            }
+            action [Heal]
         }
     }
 }

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.mdsl.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.mdsl.ts
@@ -37,21 +37,9 @@ root {
 root [ExecuteCurrentOrder] {
     selector {
         branch [Attack]
-        /*sequence {
-            condition [PlayerOrderIs, "move"]
-            selector {
-                sequence {
-                    condition [ReachedLocation]
-                    action [Stop]
-                }
-                action [MoveToTargetOrLocation, "move"]
-            }
-        }
-        sequence {
-            condition [PlayerOrderIs, "stop"]
-            action [Stop]
-        }
-        sequence {
+        branch [Move]
+        branch [Stop]
+        /* sequence {
             condition [PlayerOrderIs, "gather"]
             condition [HasHarvestComponent]
             condition [TargetHasResources]
@@ -152,6 +140,44 @@ root [Attack] {
                     /* action [Log, "Done waiting in attack"] */
                 }
             }
+        }
+    }
+}
+
+root [Move] {
+    sequence { /* ALL MUST SUCCEED */
+        condition [PlayerOrderIs, "move"]
+        /* ensure that action succeeds - we don't want to seek another action as current action is move */
+        succeed {
+            selector { /* executes until first succeeds */
+                /* if no target, stop */
+                sequence {
+                    flip {
+                        condition [TargetOrLocationExists]
+                    }
+                    action [Stop]
+                }
+
+                /* move */
+                action [MoveToTargetOrLocation, "move"]
+
+                /* if reached target, stop */
+                sequence {
+                    action [Log, "Reached target"]
+                    action [InRange, "move"]
+                    action [Stop]
+                }
+            }
+        }
+    }
+}
+
+root [Stop] {
+    sequence { /* ALL MUST SUCCEED */
+        condition [PlayerOrderIs, "stop"]
+        /* ensure that action succeeds - we don't want to seek another action as current action is stop */
+        succeed {
+            action [Stop]
         }
     }
 }

--- a/apps/client/src/app/probable-waffle/gui/instant-game/instant-game.component.ts
+++ b/apps/client/src/app/probable-waffle/gui/instant-game/instant-game.component.ts
@@ -34,7 +34,7 @@ export class InstantGameComponent implements OnInit {
 
     // const allMaps = Object.values(ProbableWaffleLevels);
     // const map = allMaps[Math.floor(Math.random() * allMaps.length)].id;
-    const map = ProbableWaffleMapEnum.RiverCrossing;
+    const map = ProbableWaffleMapEnum.Sandbox;
     await this.gameInstanceClientService.gameModeChanged("map", { map });
     await this.gameInstanceClientService.gameInstanceMetadataChanged("sessionState", {
       sessionState: GameSessionState.MovingPlayersToGame

--- a/apps/client/src/app/probable-waffle/gui/instant-game/instant-game.component.ts
+++ b/apps/client/src/app/probable-waffle/gui/instant-game/instant-game.component.ts
@@ -34,7 +34,7 @@ export class InstantGameComponent implements OnInit {
 
     // const allMaps = Object.values(ProbableWaffleLevels);
     // const map = allMaps[Math.floor(Math.random() * allMaps.length)].id;
-    const map = ProbableWaffleMapEnum.Sandbox;
+    const map = ProbableWaffleMapEnum.RiverCrossing;
     await this.gameInstanceClientService.gameModeChanged("map", { map });
     await this.gameInstanceClientService.gameInstanceMetadataChanged("sessionState", {
       sessionState: GameSessionState.MovingPlayersToGame

--- a/apps/client/src/app/probable-waffle/gui/lobby/map-selector/map-selector.component.ts
+++ b/apps/client/src/app/probable-waffle/gui/lobby/map-selector/map-selector.component.ts
@@ -1,6 +1,7 @@
 import { Component, inject } from "@angular/core";
 import { GameInstanceClientService } from "../../../communicators/game-instance-client.service";
 import { ProbableWaffleLevels, ProbableWaffleMapData, ProbableWaffleMapEnum } from "@fuzzy-waddle/api-interfaces";
+import { environment } from "../../../../../environments/environment";
 
 @Component({
   selector: "probable-waffle-map-selector",
@@ -29,6 +30,6 @@ export class MapSelectorComponent {
   }
 
   get levels(): ProbableWaffleMapData[] {
-    return Object.values(ProbableWaffleLevels);
+    return Object.values(ProbableWaffleLevels).filter((level) => (environment.production ? !level.devOnly : true));
   }
 }

--- a/apps/client/src/app/probable-waffle/gui/online/matchmaking/matchmaking.service.ts
+++ b/apps/client/src/app/probable-waffle/gui/online/matchmaking/matchmaking.service.ts
@@ -5,6 +5,7 @@ import { RoomsService } from "../../../communicators/rooms/rooms.service";
 import { FactionType, ProbableWaffleGameFoundEvent, ProbableWaffleLevels } from "@fuzzy-waddle/api-interfaces";
 import { MatchmakingLevel, MatchmakingOptions } from "./matchmaking.component";
 import { IMatchmakingService } from "./matchmaking.service.interface";
+import { environment } from "../../../../../environments/environment";
 
 @Injectable({
   providedIn: "root"
@@ -60,14 +61,16 @@ export class MatchmakingService implements IMatchmakingService {
   }
 
   private get levels(): MatchmakingLevel[] {
-    return Object.values(ProbableWaffleLevels).map((level) => ({
-      id: level.id,
-      name: level.name,
-      checked: true,
-      imagePath: level.presentation.imagePath,
-      enabled: true,
-      nrOfPlayers: level.mapInfo.startPositionsOnTile.length
-    }));
+    return Object.values(ProbableWaffleLevels)
+      .filter((level) => (environment.production ? !level.devOnly : true))
+      .map((level) => ({
+        id: level.id,
+        name: level.name,
+        checked: true,
+        imagePath: level.presentation.imagePath,
+        enabled: true,
+        nrOfPlayers: level.mapInfo.startPositionsOnTile.length
+      }));
   }
 
   get nrOfPlayersOptions(): number[] {

--- a/libs/api-interfaces/src/lib/communicators/probable-waffle/communicators.ts
+++ b/libs/api-interfaces/src/lib/communicators/probable-waffle/communicators.ts
@@ -73,7 +73,8 @@ export type ProbableWafflePlayerDataChangeEventProperty =
   | "selection.cleared"
   | "resource.added"
   | "resource.removed"
-  | "command.issued.move"; // todo this command needs to be removed from here as it belongs to actor event
+  | "command.issued.move" // todo this command needs to be removed from here as it belongs to actor event
+  | "command.issued.actor"; // todo this command needs to be removed from here as it belongs to actor event
 export interface ProbableWafflePlayerDataChangeEvent extends ProbableWaffleCommunicatorEvent {
   property: ProbableWafflePlayerDataChangeEventProperty;
   data: ProbableWafflePlayerDataChangeEventPayload;

--- a/libs/api-interfaces/src/lib/communicators/probable-waffle/listeners.ts
+++ b/libs/api-interfaces/src/lib/communicators/probable-waffle/listeners.ts
@@ -203,12 +203,18 @@ export class ProbableWaffleListeners {
           // find actors in game state by id
           const actors = gameInstance.gameState!.data.actors.filter((a) => a.id && selectedActors.includes(a.id));
           actors.forEach((actor) => {
-            if (!actor.blackboardCommands) actor.blackboardCommands = [];
-            actor.blackboardCommands.push(actor.blackboardCurrentCommand!);
+            // todo handle storing to game state
             ProbableWaffleListeners.logDebugInfo(
               `move command issued for player ${player!.playerNumber} to actor ${actor.id} at x: ${tileVec3.x}, y: ${tileVec3.y}, z: ${tileVec3.z}`
             );
           });
+          break;
+
+        case "command.issued.actor" as ProbableWafflePlayerDataChangeEventProperty:
+          player = gameInstance.getPlayerByNumber(payload.data.playerNumber!);
+          if (!player) throw new Error("Player not found with number " + payload.data.playerNumber);
+          const objectIds = payload.data.data!["objectIds"];
+          // todo store commands to game state?
           break;
 
         case "resource.added" as ProbableWafflePlayerDataChangeEventProperty:

--- a/libs/api-interfaces/src/lib/game-instance/probable-waffle/game-state.ts
+++ b/libs/api-interfaces/src/lib/game-instance/probable-waffle/game-state.ts
@@ -53,8 +53,4 @@ export interface ActorDefinition extends Record<string, any> {
   selectable?: boolean;
 
   // TODO OTHERS FOR EXAMPLE PRODUCTION COMPONENT ETC???
-
-  // BlackboardComponent
-  blackboardCurrentCommand?: ProbableWaffleGameCommand; // todo this should be filled and used by PawnAiController
-  blackboardCommands?: ProbableWaffleGameCommand[];
 }

--- a/libs/api-interfaces/src/lib/probable-waffle/probable-waffle.ts
+++ b/libs/api-interfaces/src/lib/probable-waffle/probable-waffle.ts
@@ -1,8 +1,9 @@
 import { Vector3Simple } from "../game/vector";
 
 export enum ProbableWaffleMapEnum {
-  RiverCrossing = 1,
-  EmberEnclave = 2
+  Sandbox = 1,
+  RiverCrossing = 2,
+  EmberEnclave = 3
 }
 
 export type ProbableWaffleMapType = {
@@ -11,6 +12,7 @@ export type ProbableWaffleMapType = {
 
 export type ProbableWaffleMapData = {
   id: ProbableWaffleMapEnum;
+  devOnly?: boolean;
   name: string;
   loader: {
     mapSceneKey: string;
@@ -28,6 +30,27 @@ export type ProbableWaffleMapData = {
 };
 
 export const ProbableWaffleLevels: ProbableWaffleMapType = {
+  [ProbableWaffleMapEnum.Sandbox]: {
+    id: ProbableWaffleMapEnum.Sandbox,
+    devOnly: true,
+    name: "Sandbox (dev only)",
+    loader: {
+      mapSceneKey: "MapSandbox",
+      mapLoaderAssetPackPath: "asset-pack-probable-waffle-river-crossing.json"
+    },
+    presentation: {
+      description: "Only for development purposes",
+      imagePath: "assets/probable-waffle/tilemaps/thumbnails/river_crossing.png"
+    },
+    mapInfo: {
+      startPositionsOnTile: [
+        { x: 10, y: 20, z: 0 },
+        { x: 40, y: 40, z: 0 }
+      ],
+      widthTiles: 50,
+      heightTiles: 50
+    }
+  },
   [ProbableWaffleMapEnum.RiverCrossing]: {
     id: ProbableWaffleMapEnum.RiverCrossing,
     name: "River Crossing",


### PR DESCRIPTION
* cleanup visualizer of TS types 
  - so it can be viewed here https://nikkorn.github.io/mistreevous-visualiser/index.html

* Behavior tree rework - assigning orders in queue

* Stopping current order mid-point

* Dev only map for testing behavior trees

* Stopping current order mid-point

* Action system 
  - added action system so actor orders can be determined against other actors - attack / gather / heal...

* Behavior tree:
  - added more onCooldownReady checks
  - changed attack behavior to directly attackMove
  - removed some unwanted assignments of orders

* behavior tree docs

* working attack command

* Reached location decorator

* Stopping command after successful execution

* Async IsInRange and working attack:
  - IsInRange is now promisey task until this is resolved - https://github.com/nikkorn/mistreevous/issues/95
  - attack branch is working with await for cooldown
  - attack branch auto-stops if target is dead
  - added Log task for easier debugging

* Move and Stop branches

* Gather and Return resources branches

* Build branch

* Repair branch

* Heal branch

* AutoAssignNewOrder branch

* Fixing behavior bugs

## How it looks:
![image](https://github.com/user-attachments/assets/33f5fbf3-c98f-47cf-910f-6cf992ec3e9e)