### PR TITLE
#295 Rally when building is getting constructed

### DIFF
--- a/apps/client/src/app/probable-waffle/game/data/actor-data.ts
+++ b/apps/client/src/app/probable-waffle/game/data/actor-data.ts
@@ -114,6 +114,7 @@ function gatherConstructingActorData(actor: Phaser.GameObjects.GameObject): { co
     ...(componentDefinitions?.constructable
       ? [new ConstructionSiteComponent(actor, componentDefinitions.constructable)]
       : []),
+    ...(componentDefinitions?.production ? [new ProductionComponent(actor, componentDefinitions.production)] : []),
     ...(componentDefinitions?.selectable ? [new SelectableComponent(actor)] : []),
     ...(componentDefinitions?.health ? [new HealthComponent(actor, componentDefinitions.health)] : []),
     ...(componentDefinitions?.collider ? [new ColliderComponent(actor, componentDefinitions.collider)] : [])
@@ -139,7 +140,6 @@ function gatherCompletedActorData(actor: Phaser.GameObjects.GameObject): { compo
     ...(componentDefinitions?.resourceSource
       ? [new ResourceSourceComponent(actor, componentDefinitions.resourceSource)]
       : []),
-    ...(componentDefinitions?.production ? [new ProductionComponent(actor, componentDefinitions.production)] : []),
     ...(componentDefinitions?.healing ? [new HealingComponent(actor, componentDefinitions.healing)] : []),
     ...(componentDefinitions?.builder ? [new BuilderComponent(actor, componentDefinitions.builder)] : []),
     ...(componentDefinitions?.gatherer ? [new GathererComponent(actor, componentDefinitions.gatherer)] : []),

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/gatherer-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/gatherer-component.ts
@@ -187,7 +187,7 @@ export class GathererComponent {
   private static isReadyToUse(resourceDrain: GameObject): boolean {
     const constructionSiteComponent = getActorComponent(resourceDrain, ConstructionSiteComponent);
     if (!constructionSiteComponent) return true;
-    return constructionSiteComponent.isFinished();
+    return constructionSiteComponent.isFinished;
   }
 
   // Gets the resource source the gameObject has recently been gathering from, if available, or a similar one within its sweep radius

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/owner-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/owner-component.ts
@@ -156,7 +156,7 @@ export class OwnerComponent {
     if (!constructionSiteComponent) {
       return { constructionWidth: 0, constructionHeight: 0 };
     }
-    if (constructionSiteComponent.isFinished()) {
+    if (constructionSiteComponent.isFinished) {
       this.constructionProgressSubscription?.unsubscribe();
       return { constructionWidth: 0, constructionHeight: 0 };
     }

--- a/apps/client/src/app/probable-waffle/game/entity/building/construction/construction-game-object-interface-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/building/construction/construction-game-object-interface-component.ts
@@ -30,7 +30,7 @@ export class ConstructionGameObjectInterfaceComponent {
       return;
     }
     this.constructionSiteHandlerSetup = true;
-    if (constructionSiteComponent.isFinished()) {
+    if (constructionSiteComponent.isFinished) {
       this.handlePrefabVisibility(100);
       this.onDestroy();
     } else {

--- a/apps/client/src/app/probable-waffle/game/entity/building/construction/construction-site-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/building/construction/construction-site-component.ts
@@ -181,9 +181,7 @@ export class ConstructionSiteComponent {
   }
 
   cancelConstruction() {
-    if (this.isFinished()) {
-      return;
-    }
+    if (this.isFinished) return;
 
     const productionDefinition = this.productionDefinition;
     if (!productionDefinition) throw new Error("Production definition not found");
@@ -204,12 +202,12 @@ export class ConstructionSiteComponent {
     // this.gameObject.destroy();
   }
 
-  isFinished() {
+  get isFinished() {
     return this.constructionSiteData.state === ConstructionStateEnum.Finished;
   }
 
   canAssignBuilder() {
-    return this.assignedBuilders.length < this.constructionSiteDefinition.maxAssignedBuilders && !this.isFinished();
+    return this.assignedBuilders.length < this.constructionSiteDefinition.maxAssignedBuilders && !this.isFinished;
   }
 
   assignBuilder(gameObject: GameObject) {

--- a/apps/client/src/app/probable-waffle/game/entity/building/production/production-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/building/production/production-component.ts
@@ -14,6 +14,7 @@ import { SelectableComponent } from "../../actor/components/selectable-component
 import { Subject, Subscription } from "rxjs";
 import RallyPoint from "../../../prefabs/buildings/misc/RallyPoint";
 import GameObject = Phaser.GameObjects.GameObject;
+import { ConstructionSiteComponent } from "../construction/construction-site-component";
 
 export type ProductionQueueItem = {
   actorName: ObjectNames;
@@ -76,7 +77,12 @@ export class ProductionComponent {
     return this.productionQueues.reduce((acc, queue) => acc.concat(queue.queuedItems), [] as ProductionQueueItem[]);
   }
 
+  get isFinished() {
+    return getActorComponent(this.gameObject, ConstructionSiteComponent)?.isFinished ?? true;
+  }
+
   update(time: number, delta: number): void {
+    if (!this.isFinished) return;
     // process all queues
     for (let i = 0; i < this.productionQueues.length; i++) {
       const queue = this.productionQueues[i];
@@ -160,6 +166,7 @@ export class ProductionComponent {
   }
 
   startProduction(queueItem: ProductionQueueItem): AssignProductionErrorCode | null {
+    if (!this.isFinished) return AssignProductionErrorCode.NotFinished;
     const productionState = this.canAssignProduction(queueItem);
     if (productionState) {
       return productionState;
@@ -296,6 +303,7 @@ export class ProductionComponent {
   }
 
   private canAssignProduction(item: ProductionQueueItem): AssignProductionErrorCode | null {
+    if (!this.isFinished) return AssignProductionErrorCode.NotFinished;
     // check if gameObject can be produced
     if (!this.productionDefinition.availableProduceActors.includes(item.actorName))
       return AssignProductionErrorCode.InvalidProduct;
@@ -331,6 +339,7 @@ export class ProductionComponent {
   }
 
   cancelProduction(item: ProductionQueueItem) {
+    if (!this.isFinished) return;
     for (let i = 0; i < this.productionQueues.length; i++) {
       const queue = this.productionQueues[i];
       const index = queue.queuedItems.findIndex((i) => i.actorName === item.actorName);
@@ -405,5 +414,6 @@ export enum AssignProductionErrorCode {
   NotEnoughResources = 1,
   QueueFull = 2,
   InvalidProduct = 3,
-  NoOwner = 4
+  NoOwner = 4,
+  NotFinished
 }

--- a/apps/client/src/app/probable-waffle/game/entity/combat/components/health-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/combat/components/health-component.ts
@@ -106,7 +106,7 @@ export class HealthComponent {
 
   private init() {
     const constructionSiteComponent = getActorComponent(this.gameObject, ConstructionSiteComponent);
-    if (constructionSiteComponent && !constructionSiteComponent.isFinished()) {
+    if (constructionSiteComponent && !constructionSiteComponent.isFinished) {
       const shouldBeVisible = this.shouldUiElementsBeVisible;
       this.setVisibilityUiComponent(false);
       this.shouldUiElementsBeVisible = shouldBeVisible;
@@ -245,7 +245,7 @@ export class HealthComponent {
     if (!this.gameObject.active) return;
     this.shouldUiElementsBeVisible = visibility;
     const constructionSiteComponent = getActorComponent(this.gameObject, ConstructionSiteComponent);
-    if (constructionSiteComponent && !constructionSiteComponent.isFinished()) visibility = false;
+    if (constructionSiteComponent && !constructionSiteComponent.isFinished) visibility = false;
     const previousVisibility = this.uiComponentsVisible;
     if (visibility === previousVisibility) return;
     this.healthUiComponent.setVisibility(visibility);

--- a/apps/client/src/app/probable-waffle/game/entity/systems/action.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/action.system.ts
@@ -84,7 +84,7 @@ export class ActionSystem {
         if (targetIsBuilding) {
           // target is building
 
-          if (!targetIsBuilding.isFinished()) {
+          if (!targetIsBuilding.isFinished) {
             // Building is not finished
 
             const selfBuilderComponent = getActorComponent(this.gameObject, BuilderComponent);

--- a/apps/client/src/app/probable-waffle/game/prefabs/gui/buttons/ActorActions.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/gui/buttons/ActorActions.ts
@@ -305,7 +305,7 @@ export default class ActorActions extends Phaser.GameObjects.Container {
 
   private showProductionIcons(actor: Phaser.GameObjects.GameObject, index: number): number {
     const productionComponent = getActorComponent(actor, ProductionComponent);
-    if (productionComponent) {
+    if (productionComponent && productionComponent.isFinished) {
       const availableToProduce = productionComponent.productionDefinition.availableProduceActors;
       availableToProduce.forEach((product) => {
         const actorDefinition = pwActorDefinitions[product];
@@ -346,6 +346,9 @@ export default class ActorActions extends Phaser.GameObjects.Container {
                   HudMessages.HudVisualFeedbackMessageEventName,
                   HudVisualFeedbackMessageType.ProductionQueueFull
                 );
+                break;
+              case AssignProductionErrorCode.NotFinished:
+                console.error("Not finished");
                 break;
               case AssignProductionErrorCode.InvalidProduct:
                 console.error("Invalid product");

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
@@ -534,7 +534,7 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent, 
     if (!target) return false;
     const constructionSiteComponent = getActorComponent(target, ConstructionSiteComponent);
     if (!constructionSiteComponent) return false;
-    return constructionSiteComponent.isFinished();
+    return constructionSiteComponent.isFinished;
   }
   TargetHealthFull(): boolean {
     const currentOrder = this.blackboard.getCurrentOrder();


### PR DESCRIPTION
## Changes
- moving ProductionComponent init to `gatherConstructingActorData` so rally point is available when building is getting built
- adjusting actorActions so they don't show if building is not fully built yet