### PR TITLE
#76 FOW restrict playing of sounds if not visible

### DIFF
--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/gatherer-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/gatherer-component.ts
@@ -21,7 +21,7 @@ import { AnimationActorComponent, AnimationType } from "./animation-actor-compon
 import { OrderType } from "../../character/ai/order-type";
 import { ActorTranslateComponent } from "./actor-translate-component";
 import GameObject = Phaser.GameObjects.GameObject;
-import { onObjectReady } from "../../../data/game-object-helper";
+import { getGameObjectVisibility, onObjectReady } from "../../../data/game-object-helper";
 
 export type GathererDefinition = {
   // types of gameObjects the gatherer can gather resourcesFrom
@@ -426,7 +426,10 @@ export class GathererComponent {
     }
 
     const randomSound = sounds[Math.floor(Math.random() * sounds.length)];
-    this.audioService.playSpatialAudioSprite(this.gameObject, randomSound.key, randomSound.spriteName);
+    const visibilityComponent = getGameObjectVisibility(this.gameObject);
+    if (visibilityComponent && visibilityComponent.visible) {
+      this.audioService.playSpatialAudioSprite(this.gameObject, randomSound.key, randomSound.spriteName);
+    }
   }
 
   private playGatherAnimation() {

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/representable-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/representable-component.ts
@@ -127,10 +127,4 @@ export class RepresentableComponent {
     }
     return this._visible;
   }
-  get width(): number {
-    return this.representableDefinition.width;
-  }
-  get height(): number {
-    return this.representableDefinition.height;
-  }
 }

--- a/apps/client/src/app/probable-waffle/game/entity/building/construction/construction-site-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/building/construction/construction-site-component.ts
@@ -7,7 +7,7 @@ import { emitResource, getPlayer } from "../../../data/scene-data";
 import { pwActorDefinitions } from "../../../data/actor-definitions";
 import { ObjectNames } from "../../../data/object-names";
 import { ProductionCostDefinition } from "../production/production-cost-component";
-import { onObjectReady } from "../../../data/game-object-helper";
+import { getGameObjectVisibility, onObjectReady } from "../../../data/game-object-helper";
 import { BehaviorSubject, Subject } from "rxjs";
 import { upgradeFromConstructingToFullActorData } from "../../../data/actor-data";
 import { ConstructionProgressUiComponent } from "./construction-progress-ui-component";
@@ -158,6 +158,8 @@ export class ConstructionSiteComponent {
 
   private playBuildSound() {
     if (!this.audioService) return;
+    const visibilityComponent = getGameObjectVisibility(this.gameObject);
+    if (!visibilityComponent || !visibilityComponent.visible) return;
     if (this.playingBuildSound) return;
     this.playingBuildSound = true;
     const soundDefinitions = [...SharedActorActionsSfxHammeringSounds, ...SharedActorActionsSfxSawingSounds];
@@ -312,9 +314,12 @@ export class ConstructionSiteComponent {
     this.constructionSiteData.state = ConstructionStateEnum.Finished;
     this.constructionStateChanged.next(this.constructionSiteData.state);
 
-    const soundDefinitions = SharedActorActionsSfxSelectionSounds;
-    const soundDefinition = soundDefinitions[Math.floor(Math.random() * soundDefinitions.length)];
-    this.audioService?.playSpatialAudioSprite(this.gameObject, soundDefinition.key, soundDefinition.spriteName);
+    const visibilityComponent = getGameObjectVisibility(this.gameObject);
+    if (visibilityComponent && visibilityComponent.visible) {
+      const soundDefinitions = SharedActorActionsSfxSelectionSounds;
+      const soundDefinition = soundDefinitions[Math.floor(Math.random() * soundDefinitions.length)];
+      this.audioService?.playSpatialAudioSprite(this.gameObject, soundDefinition.key, soundDefinition.spriteName);
+    }
 
     if (this.constructionSiteDefinition.consumesBuilders) {
       this.assignedBuilders.forEach((builder) => {

--- a/apps/client/src/app/probable-waffle/game/entity/combat/components/attack-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/combat/components/attack-component.ts
@@ -2,7 +2,12 @@ import { AttackData, ProjectileData, ProjectileType } from "../attack-data";
 import { HealthComponent } from "./health-component";
 import { getActorComponent } from "../../../data/actor-component";
 import { AnimationActorComponent, AnimationOptions } from "../../actor/components/animation-actor-component";
-import { getGameObjectBounds, getGameObjectDepth, onObjectReady } from "../../../data/game-object-helper";
+import {
+  getGameObjectBounds,
+  getGameObjectDepth,
+  getGameObjectVisibility,
+  onObjectReady
+} from "../../../data/game-object-helper";
 import { OrderType } from "../../character/ai/order-type";
 import { ActorTranslateComponent } from "../../actor/components/actor-translate-component";
 import { getSceneService } from "../../../scenes/components/scene-component-helpers";
@@ -242,12 +247,15 @@ export class AttackComponent {
 
     // play hit sound
     if (this.audioService && attack.sounds.hit) {
-      const randomHitSound = attack.sounds.hit[Math.floor(Math.random() * attack.sounds.hit.length)];
-      this.audioService.playSpatialAudioSprite(
-        enemy, // enemy hit position
-        randomHitSound.key,
-        randomHitSound.spriteName
-      );
+      const visibilityComponent = getGameObjectVisibility(this.gameObject);
+      if (visibilityComponent && visibilityComponent.visible) {
+        const randomHitSound = attack.sounds.hit[Math.floor(Math.random() * attack.sounds.hit.length)];
+        this.audioService.playSpatialAudioSprite(
+          enemy, // enemy hit position
+          randomHitSound.key,
+          randomHitSound.spriteName
+        );
+      }
     }
     this.stopProjectile();
     if (projectile.impactAnimation) {
@@ -307,17 +315,23 @@ export class AttackComponent {
     if (!this.audioService) return;
     const { preparing, fire, hit } = attack.sounds;
     if (preparing) {
-      const randomPreparingSound = preparing[Math.floor(Math.random() * preparing.length)];
-      this.audioService.playSpatialAudioSprite(
-        this.gameObject,
-        randomPreparingSound.key,
-        randomPreparingSound.spriteName
-      );
+      const visibilityComponent = getGameObjectVisibility(this.gameObject);
+      if (visibilityComponent && visibilityComponent.visible) {
+        const randomPreparingSound = preparing[Math.floor(Math.random() * preparing.length)];
+        this.audioService.playSpatialAudioSprite(
+          this.gameObject,
+          randomPreparingSound.key,
+          randomPreparingSound.spriteName
+        );
+      }
     }
     setTimeout(() => {
       if (fire) {
-        const randomFireSound = fire[Math.floor(Math.random() * fire.length)];
-        this.audioService!.playSpatialAudioSprite(this.gameObject, randomFireSound.key, randomFireSound.spriteName);
+        const visibilityComponent = getGameObjectVisibility(this.gameObject);
+        if (visibilityComponent && visibilityComponent.visible) {
+          const randomFireSound = fire[Math.floor(Math.random() * fire.length)];
+          this.audioService!.playSpatialAudioSprite(this.gameObject, randomFireSound.key, randomFireSound.spriteName);
+        }
       }
     }, attack.delays.fire);
 
@@ -325,12 +339,15 @@ export class AttackComponent {
       // if not a projectile, play hit sound
       setTimeout(() => {
         if (hit) {
-          const randomHitSound = hit[Math.floor(Math.random() * hit.length)];
-          this.audioService!.playSpatialAudioSprite(
-            enemy, // enemy hit position
-            randomHitSound.key,
-            randomHitSound.spriteName
-          );
+          const visibilityComponent = getGameObjectVisibility(this.gameObject);
+          if (visibilityComponent && visibilityComponent.visible) {
+            const randomHitSound = hit[Math.floor(Math.random() * hit.length)];
+            this.audioService!.playSpatialAudioSprite(
+              enemy, // enemy hit position
+              randomHitSound.key,
+              randomHitSound.spriteName
+            );
+          }
         }
       }, attack.delays.hit);
     }

--- a/apps/client/src/app/probable-waffle/game/entity/combat/components/health-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/combat/components/health-component.ts
@@ -8,7 +8,7 @@ import { ContainerComponent } from "../../building/container-component";
 import Phaser from "phaser";
 import { getActorComponent } from "../../../data/actor-component";
 import { ConstructionSiteComponent } from "../../building/construction/construction-site-component";
-import { getGameObjectDepth, onObjectReady } from "../../../data/game-object-helper";
+import { getGameObjectDepth, getGameObjectVisibility, onObjectReady } from "../../../data/game-object-helper";
 import { environment } from "../../../../../../environments/environment";
 import { SelectableComponent } from "../../actor/components/selectable-component";
 import { OwnerComponent } from "../../actor/components/owner-component";
@@ -323,6 +323,8 @@ export class HealthComponent {
   }
 
   private playDeathSound() {
+    const visibilityComponent = getGameObjectVisibility(this.gameObject);
+    if (!visibilityComponent || !visibilityComponent.visible) return;
     let randomSound: SoundDefinition;
     let randomSoundIndex: number;
     switch (this.healthDefinition.physicalState) {

--- a/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
@@ -10,6 +10,7 @@ import {
   getGameObjectTileInRadius,
   getGameObjectTransform,
   getGameObjectTransformRaw,
+  getGameObjectVisibility,
   onObjectReady
 } from "../../data/game-object-helper";
 import { Subscription } from "rxjs";
@@ -357,6 +358,8 @@ export class MovementSystem {
 
   private playMovementSound() {
     if (!this.audioService) return;
+    const visibilityComponent = getGameObjectVisibility(this.gameObject);
+    if (!visibilityComponent || !visibilityComponent.visible) return;
     const movementSoundDefinition = this.getMovementSound();
     if (!movementSoundDefinition) return;
     // get random from movementSoundDefinition

--- a/apps/client/src/app/probable-waffle/game/prefabs/units/skaduwee/SkaduweeOwl.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/units/skaduwee/SkaduweeOwl.ts
@@ -6,7 +6,7 @@
 
 import { HealthComponent } from "../../../entity/combat/components/health-component";
 import { moveGameObjectToRandomTileInNavigableRadius, MovementSystem } from "../../../entity/systems/movement.system";
-import { onObjectReady } from "../../../data/game-object-helper";
+import { getGameObjectVisibility, onObjectReady } from "../../../data/game-object-helper";
 import { getActorSystem } from "../../../data/actor-system";
 import { ObjectNames } from "../../../data/object-names";
 import { getSceneService } from "../../../scenes/components/scene-component-helpers";
@@ -94,6 +94,8 @@ export default class SkaduweeOwl extends Phaser.GameObjects.Container {
 
   private playMoveSound() {
     if (!this.audioService) return;
+    const visibilityComponent = getGameObjectVisibility(this);
+    if (!visibilityComponent || !visibilityComponent.visible) return;
     const movementSoundDefinition = SkaduweeOwlSfxMoveSounds;
     const randomIndex = Math.floor(Math.random() * movementSoundDefinition.length);
     const movementSound = movementSoundDefinition[randomIndex];
@@ -104,6 +106,8 @@ export default class SkaduweeOwl extends Phaser.GameObjects.Container {
 
   private playFurballSound(definitions: SoundDefinition[]) {
     if (!this.audioService) return;
+    const visibilityComponent = getGameObjectVisibility(this);
+    if (!visibilityComponent || !visibilityComponent.visible) return;
     const randomIndex = Math.floor(Math.random() * definitions.length);
     const fireSound = definitions[randomIndex];
     this.audioService.playSpatialAudioSprite(this, fireSound.key, fireSound.spriteName);


### PR DESCRIPTION
This pull request introduces a visibility check for game objects before playing spatial audio across various components and systems. This ensures that sounds are only played for visible game objects, improving performance and preventing unnecessary audio playback. Additionally, unused properties were removed from the `RepresentableComponent` class.

### Visibility checks for spatial audio:

* **`GathererComponent`**: Added a visibility check using `getGameObjectVisibility` before playing spatial audio for gatherer-related actions.
* **`ConstructionSiteComponent`**: Implemented visibility checks in multiple methods to ensure sounds for building and construction completion are only played for visible objects. [[1]](diffhunk://#diff-37b83bd78bc28c546b5b6486ec2c7ced106b48430ea57b0b2339b3dc07d1fb03R161-R162) [[2]](diffhunk://#diff-37b83bd78bc28c546b5b6486ec2c7ced106b48430ea57b0b2339b3dc07d1fb03R317-R322)
* **`AttackComponent`**: Incorporated visibility checks in methods handling attack sounds, including hit, fire, and preparation sounds. [[1]](diffhunk://#diff-9115ca4640bceb26fa8cf8d473a8ea5c99cac8331597f973a0bb48ef85d0a2fcR250-R259) [[2]](diffhunk://#diff-9115ca4640bceb26fa8cf8d473a8ea5c99cac8331597f973a0bb48ef85d0a2fcR318-R351)
* **`HealthComponent`**: Added a visibility check before playing death sounds for game objects.
* **`MovementSystem` and `SkaduweeOwl`**: Added visibility checks in movement-related sound methods to prevent audio playback for invisible entities. [[1]](diffhunk://#diff-8f343e20d759d4e2b32f119d36e374ce69f0cfaa21aab63ec86c988f29da23c0R361-R362) [[2]](diffhunk://#diff-34130dc1dc86b9e2b7fe1dad04729af92ebd2ab3f542c873f327e6ff00e90942R97-R98) [[3]](diffhunk://#diff-34130dc1dc86b9e2b7fe1dad04729af92ebd2ab3f542c873f327e6ff00e90942R109-R110)

### Code cleanup:

* **`RepresentableComponent`**: Removed unused `width` and `height` properties, simplifying the class.