### PR TITLE
#387 higher z level

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,16 @@
+# Copilot Instructions
+
+## General Guidelines
+
+- **Preserve Existing Comments**: When updating code, never remove, overwrite, or substantially alter existing code comments. Comments should be kept intact unless specifically instructed otherwise.
+- **Respect Code Annotations**: Maintain any TODO, FIXME, or other annotated notes in the code.
+
+## Example
+
+When refactoring or updating code:
+- Existing comments explaining logic, usage, or context must always be kept.
+- If new comments are added, ensure they do not duplicate or contradict existing ones.
+
+## Rationale
+
+Comments provide essential context for future development and debugging. Removing them could hinder understanding or maintenance of the codebase.

--- a/.github/git-commit-instructions.md
+++ b/.github/git-commit-instructions.md
@@ -1,0 +1,32 @@
+# Git Commit Instructions
+
+## Commit Message Format
+
+- Start with the ticket number (e\.g\., `#376`)
+- Use the present tense ("Add feature" not "Added feature")
+- Start with a short summary (max 50 characters)
+- Separate subject from body with a blank line
+- Use the body to explain what and why (not how). Do that in a few bullet points in short sentences.
+- Reference issues and pull requests when relevant
+
+## Example
+
+```
+#376 feat: add user authentication
+
+## Changes
+- Added JWT-based authentication to the login endpoint.
+- Implemented user registration with email verification.
+## Motivation
+This feature allows users to securely log in and register, enhancing the overall security of the application.
+```
+
+## Types
+
+- feat: A new feature
+- fix: A bug fix
+- docs: Documentation only changes
+- style: Code style changes (formatting, missing semi colons, etc)
+- refactor: Code changes that neither fix a bug nor add a feature
+- test: Adding or fixing tests
+- chore: Maintenance tasks

--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -5,7 +5,7 @@
       <driver-ref>postgresql</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>org.postgresql.Driver</jdbc-driver>
-      <jdbc-url>jdbc:postgresql://db.bhzetyxjimpabioxoodz.supabase.co:5432/postgres</jdbc-url>
+      <jdbc-url>jdbc:postgresql://aws-0-eu-central-1.pooler.supabase.com:6543/postgres</jdbc-url>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
   </component>

--- a/apps/client/src/app/home/page/home-page.component.ts
+++ b/apps/client/src/app/home/page/home-page.component.ts
@@ -59,7 +59,8 @@ export class HomePageComponent {
       description: "Creepy crawlies",
       image: "dungeon-crawler.webp",
       bannerImage: "dungeon-crawler-banner.webp",
-      route: "dungeon-crawler"
+      route: "dungeon-crawler",
+      inDevelopment: true
     }
   ];
 

--- a/apps/client/src/app/probable-waffle/game/data/actor-data.ts
+++ b/apps/client/src/app/probable-waffle/game/data/actor-data.ts
@@ -67,10 +67,12 @@ export function setActorData(
 
 function setActorProperties(actor: GameObject, actorDefinition?: Partial<ActorDefinition>) {
   if (!actorDefinition) return;
-  const transform = actor as any as Transform;
-  if (transform.x !== undefined && actorDefinition.x !== undefined) transform.x = actorDefinition.x;
-  if (transform.y !== undefined && actorDefinition.y !== undefined) transform.y = actorDefinition.y;
-  if (transform.z !== undefined && actorDefinition.z !== undefined) transform.z = actorDefinition.z;
+  if (actorDefinition.logicalWorldTransform) {
+    const representableComponent = getActorComponent(actor, RepresentableComponent);
+    if (representableComponent) {
+      representableComponent.logicalWorldTransform = actorDefinition.logicalWorldTransform;
+    }
+  }
   if (actorDefinition.owner) getActorComponent(actor, OwnerComponent)?.setOwner(actorDefinition.owner);
   if (actorDefinition.selectable)
     getActorComponent(actor, SelectableComponent)?.setSelected(actorDefinition.selectable);

--- a/apps/client/src/app/probable-waffle/game/data/actor-data.ts
+++ b/apps/client/src/app/probable-waffle/game/data/actor-data.ts
@@ -32,6 +32,7 @@ import { RepresentableComponent } from "../entity/actor/components/representable
 import GameObject = Phaser.GameObjects.GameObject;
 import Transform = Phaser.GameObjects.Components.Transform;
 import { FlightComponent } from "../entity/actor/components/flight-component";
+import { WalkableComponent } from "../entity/actor/components/walkable-component";
 
 export const ActorDataKey = "actorData";
 export class ActorData {
@@ -154,6 +155,7 @@ function gatherCompletedActorData(actor: Phaser.GameObjects.GameObject): { compo
       ? [new ActorTranslateComponent(actor, componentDefinitions.translatable)]
       : []),
     ...(componentDefinitions?.flying ? [new FlightComponent(actor, componentDefinitions.flying)] : []),
+    ...(componentDefinitions?.walkable ? [new WalkableComponent(actor, componentDefinitions.walkable)] : []),
     ...(componentDefinitions?.animatable ? [new AnimationActorComponent(actor, componentDefinitions.animatable)] : []),
     ...(componentDefinitions?.aiControlled ? [new PawnAiController(actor, componentDefinitions.aiControlled)] : [])
   ];

--- a/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
+++ b/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
@@ -1839,7 +1839,7 @@ export const pwActorDefinitions: {
         range: 10
       },
       walkable: {
-        walkableHeight: 16
+        walkableHeight: 32
       },
       selectable: {},
       health: {
@@ -1893,7 +1893,7 @@ export const pwActorDefinitions: {
       },
       selectable: {},
       walkable: {
-        walkableHeight: 64
+        walkableHeight: 128
       },
       health: {
         physicalState: ActorPhysicalType.Structural,
@@ -1972,7 +1972,7 @@ export const pwActorDefinitions: {
         canBeDragPlaced: true
       },
       walkable: {
-        walkableHeight: 32
+        walkableHeight: 64
       }
     }
   },

--- a/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
+++ b/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
@@ -1839,7 +1839,9 @@ export const pwActorDefinitions: {
         range: 10
       },
       walkable: {
-        walkableHeight: 32
+        walkableHeight: 32,
+        exitHeight: 64,
+        acceptMinimumHeight: 0
       },
       selectable: {},
       health: {
@@ -1893,7 +1895,10 @@ export const pwActorDefinitions: {
       },
       selectable: {},
       walkable: {
-        walkableHeight: 128
+        walkableHeight: 128,
+        exitHeight: 128,
+        // can be accessed from the stairs or a wall
+        acceptMinimumHeight: 64
       },
       health: {
         physicalState: ActorPhysicalType.Structural,
@@ -1972,7 +1977,10 @@ export const pwActorDefinitions: {
         canBeDragPlaced: true
       },
       walkable: {
-        walkableHeight: 64
+        walkableHeight: 64,
+        exitHeight: 64,
+        // can be accessed from the stairs
+        acceptMinimumHeight: 64
       }
     }
   },

--- a/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
+++ b/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
@@ -1839,7 +1839,7 @@ export const pwActorDefinitions: {
         range: 10
       },
       walkable: {
-        walkableHeight: 32
+        walkableHeight: 16
       },
       selectable: {},
       health: {
@@ -1893,7 +1893,7 @@ export const pwActorDefinitions: {
       },
       selectable: {},
       walkable: {
-        walkableHeight: 96
+        walkableHeight: 64
       },
       health: {
         physicalState: ActorPhysicalType.Structural,
@@ -1972,7 +1972,7 @@ export const pwActorDefinitions: {
         canBeDragPlaced: true
       },
       walkable: {
-        walkableHeight: 64
+        walkableHeight: 32
       }
     }
   },

--- a/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
+++ b/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
@@ -175,6 +175,7 @@ import {
 } from "../animations/animals2";
 import { RepresentableDefinition } from "../entity/actor/components/representable-component";
 import { FlightDefinition } from "../entity/actor/components/flight-component";
+import { WalkableDefinition } from "../entity/actor/components/walkable-component";
 
 const coreConstructionSiteDefinition: ConstructionSiteDefinition = {
   consumesBuilders: false,
@@ -352,6 +353,7 @@ export type ActorInfoDefinition = Partial<{
     requirements: RequirementsDefinition;
     builder: BuilderDefinition;
     constructable: ConstructionSiteDefinition;
+    walkable: WalkableDefinition;
     gatherer: GathererDefinition;
     container: ContainerDefinition;
     resourceDrain: ResourceDrainDefinition;
@@ -1836,6 +1838,9 @@ export const pwActorDefinitions: {
       vision: {
         range: 10
       },
+      walkable: {
+        walkableHeight: 32
+      },
       selectable: {},
       health: {
         physicalState: ActorPhysicalType.Structural,
@@ -1887,6 +1892,9 @@ export const pwActorDefinitions: {
         }
       },
       selectable: {},
+      walkable: {
+        walkableHeight: 96
+      },
       health: {
         physicalState: ActorPhysicalType.Structural,
         maxHealth: 1000,
@@ -1961,6 +1969,9 @@ export const pwActorDefinitions: {
       constructable: {
         ...coreConstructionSiteDefinition,
         canBeDragPlaced: true
+      },
+      walkable: {
+        walkableHeight: 64
       }
     }
   },

--- a/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
+++ b/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
@@ -1909,9 +1909,10 @@ export const pwActorDefinitions: {
         productionTime: 5000,
         costType: PaymentType.PayImmediately
       },
-      container: {
-        capacity: 2
-      },
+      // note - this unit can be walked on and can not contain units
+      // container: {
+      //   capacity: 2
+      // },
       attack: {
         attacks: [weaponDefinitions.bowTower]
       },

--- a/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
+++ b/apps/client/src/app/probable-waffle/game/data/actor-definitions.ts
@@ -1839,7 +1839,7 @@ export const pwActorDefinitions: {
         range: 10
       },
       walkable: {
-        walkableHeight: 32,
+        walkableHeight: 24,
         exitHeight: 64,
         acceptMinimumHeight: 0
       },
@@ -1977,7 +1977,7 @@ export const pwActorDefinitions: {
         canBeDragPlaced: true
       },
       walkable: {
-        walkableHeight: 64,
+        walkableHeight: 42,
         exitHeight: 64,
         // can be accessed from the stairs
         acceptMinimumHeight: 64

--- a/apps/client/src/app/probable-waffle/game/data/actor-manager.ts
+++ b/apps/client/src/app/probable-waffle/game/data/actor-manager.ts
@@ -43,8 +43,8 @@ import StonePile from "../prefabs/outside/resources/StonePile";
 import { SkaduweeWorker } from "../prefabs/characters/skaduwee/SkaduweeWorker";
 import { TivaraWorker } from "../prefabs/characters/tivara/TivaraWorker";
 import { pwActorDefinitions } from "./actor-definitions";
+import { RepresentableComponent } from "../entity/actor/components/representable-component";
 import GameObject = Phaser.GameObjects.GameObject;
-import Transform = Phaser.GameObjects.Components.Transform;
 
 export type ActorConstructor = new (scene: Phaser.Scene) => GameObject;
 export type ActorMap = { [name: string]: ActorConstructor };
@@ -136,10 +136,9 @@ export class ActorManager {
     const actorDefinition: ActorDefinition = {
       name: actorName
     };
-    const transform = actor as any as Transform;
-    if (transform.x !== undefined) actorDefinition.x = transform.x;
-    if (transform.y !== undefined) actorDefinition.y = transform.y;
-    if (transform.z !== undefined) actorDefinition.z = transform.z;
+
+    const representableComponent = getActorComponent(actor, RepresentableComponent);
+    if (representableComponent) actorDefinition.logicalWorldTransform = representableComponent?.logicalWorldTransform;
     const ownerComponent = getActorComponent(actor, OwnerComponent);
     if (ownerComponent) actorDefinition.owner = ownerComponent.getOwner();
     const selectableComponent = getActorComponent(actor, SelectableComponent);

--- a/apps/client/src/app/probable-waffle/game/data/game-object-helper.ts
+++ b/apps/client/src/app/probable-waffle/game/data/game-object-helper.ts
@@ -34,7 +34,7 @@ export function getGameObjectTransform(gameObject?: Phaser.GameObjects.GameObjec
   if (!gameObject) return null;
   const representableComponent = getActorComponent(gameObject, RepresentableComponent);
   if (representableComponent) {
-    return representableComponent.worldTransform;
+    return representableComponent.renderedWorldTransform;
   }
   return getGameObjectTransformRaw(gameObject);
 }

--- a/apps/client/src/app/probable-waffle/game/data/game-object-helper.ts
+++ b/apps/client/src/app/probable-waffle/game/data/game-object-helper.ts
@@ -30,16 +30,31 @@ export function getGameObjectDepth(gameObject: Phaser.GameObjects.GameObject): n
   return depthComponent.depth;
 }
 
-export function getGameObjectTransform(gameObject?: Phaser.GameObjects.GameObject): Vector3Simple | null {
+export function getGameObjectRenderedTransform(gameObject?: Phaser.GameObjects.GameObject): Vector2Simple | null {
   if (!gameObject) return null;
   const representableComponent = getActorComponent(gameObject, RepresentableComponent);
   if (representableComponent) {
     return representableComponent.renderedWorldTransform;
   }
-  return getGameObjectTransformRaw(gameObject);
+  return getGameObjectRenderedTransformRaw(gameObject);
 }
 
-export function getGameObjectTransformRaw(gameObject?: Phaser.GameObjects.GameObject): Vector3Simple | null {
+export function getGameObjectLogicalTransform(gameObject?: Phaser.GameObjects.GameObject): Vector3Simple | null {
+  if (!gameObject) return null;
+  const representableComponent = getActorComponent(gameObject, RepresentableComponent);
+  if (representableComponent) {
+    return representableComponent.logicalWorldTransform;
+  }
+  const transformComponent = gameObject as unknown as Phaser.GameObjects.Components.Transform;
+  if (!transformComponent.hasTransformComponent) return null;
+  return {
+    x: transformComponent.x ?? 0,
+    y: transformComponent.y ?? 0,
+    z: transformComponent.z ?? 0
+  } satisfies Vector3Simple;
+}
+
+export function getGameObjectRenderedTransformRaw(gameObject?: Phaser.GameObjects.GameObject): Vector2Simple | null {
   if (!gameObject) return null;
   const transformComponent = gameObject as unknown as Phaser.GameObjects.Components.Transform;
   if (!transformComponent.hasTransformComponent) return null;

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/actor-translate-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/actor-translate-component.ts
@@ -84,7 +84,7 @@ export class ActorTranslateComponent {
   moveActorToPosition(worldPosition: Vector3Simple) {
     this._actorMoved.next(worldPosition);
     if (this.representableComponent) {
-      this.representableComponent.worldTransform = worldPosition;
+      this.representableComponent.logicalWorldTransform = worldPosition;
     }
   }
 }

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/actor-translate-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/actor-translate-component.ts
@@ -1,7 +1,7 @@
 import { Observable, Subject } from "rxjs";
 import { Vector2Simple, Vector3Simple } from "@fuzzy-waddle/api-interfaces";
 import { getGameObjectDirectionBetweenTiles } from "../../systems/movement.system";
-import { getGameObjectTransform, onObjectReady } from "../../../data/game-object-helper";
+import { getGameObjectRenderedTransform, onObjectReady } from "../../../data/game-object-helper";
 import { getSceneService } from "../../../scenes/components/scene-component-helpers";
 import { NavigationService } from "../../../scenes/services/navigation.service";
 import { getActorComponent } from "../../../data/actor-component";
@@ -17,7 +17,7 @@ export interface ActorTranslateDefinition {
 }
 
 export class ActorTranslateComponent {
-  private _actorMoved: Subject<Vector3Simple> = new Subject<Vector3Simple>();
+  private _actorMovedLogicalPosition: Subject<Vector3Simple> = new Subject<Vector3Simple>();
   currentDirection?: IsoDirection;
   onDirectionChanged: Subject<IsoDirection> = new Subject<IsoDirection>();
   private representableComponent?: RepresentableComponent;
@@ -30,18 +30,18 @@ export class ActorTranslateComponent {
   init() {
     this.representableComponent = getActorComponent(this.gameObject, RepresentableComponent);
   }
-  get currentTileWorldXY(): Vector2Simple {
-    const transform = getGameObjectTransform(this.gameObject);
+  get renderedTransform(): Vector2Simple {
+    const transform = getGameObjectRenderedTransform(this.gameObject);
     if (!transform) return { x: 0, y: 0 };
     return { x: transform.x, y: transform.y };
   }
 
-  get actorMoved(): Observable<Vector3Simple> {
-    return this._actorMoved.asObservable();
+  get actorMovedLogicalPosition(): Observable<Vector3Simple> {
+    return this._actorMovedLogicalPosition.asObservable();
   }
 
   updateDirection(newTileWorldXY: Vector2Simple) {
-    const transform = getGameObjectTransform(this.gameObject);
+    const transform = getGameObjectRenderedTransform(this.gameObject);
     if (!transform) return;
     const newDirection = getGameObjectDirectionBetweenTiles(transform, newTileWorldXY);
     if (this.currentDirection === newDirection) return;
@@ -49,15 +49,15 @@ export class ActorTranslateComponent {
   }
 
   turnTowardsGameObject(targetGameObject: Phaser.GameObjects.GameObject) {
-    const transform = getGameObjectTransform(this.gameObject);
+    const transform = getGameObjectRenderedTransform(this.gameObject);
     if (!transform) return;
-    const targetTransform = getGameObjectTransform(targetGameObject);
+    const targetTransform = getGameObjectRenderedTransform(targetGameObject);
     if (!targetTransform) return;
     this.turnTowardsPosition({ x: targetTransform.x, y: targetTransform.y });
   }
 
   turnTowardsPosition(targetWorldXY: Vector2Simple) {
-    const transform = getGameObjectTransform(this.gameObject);
+    const transform = getGameObjectRenderedTransform(this.gameObject);
     if (!transform) return;
     const newDirection = getGameObjectDirectionBetweenTiles(transform, targetWorldXY);
     this.directionChanged(newDirection);
@@ -81,10 +81,10 @@ export class ActorTranslateComponent {
    * This should be called by movement system - action to move actor to position is broadcast to all players in the game.
    * This is to update all listeners in clients world about small movement changes - not to broadcast this across network
    */
-  moveActorToPosition(worldPosition: Vector3Simple) {
-    this._actorMoved.next(worldPosition);
+  moveActorToLogicalPosition(logicalPosition: Vector3Simple) {
+    this._actorMovedLogicalPosition.next(logicalPosition);
     if (this.representableComponent) {
-      this.representableComponent.logicalWorldTransform = worldPosition;
+      this.representableComponent.logicalWorldTransform = logicalPosition;
     }
   }
 }

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/flight-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/flight-component.ts
@@ -29,7 +29,7 @@ export class FlightComponent {
   private subscribeActorMove() {
     const actorTranslateComponent = getActorComponent(this.gameObject, ActorTranslateComponent);
     if (!actorTranslateComponent) return;
-    this.actorMovedSubscription = actorTranslateComponent.actorMoved.subscribe(() => {
+    this.actorMovedSubscription = actorTranslateComponent.actorMovedLogicalPosition.subscribe(() => {
       this.updateActorTranslateIndicators();
     });
   }

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/owner-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/owner-component.ts
@@ -205,7 +205,7 @@ export class OwnerComponent {
   private subscribeActorMove() {
     const actorTranslateComponent = getActorComponent(this.gameObject, ActorTranslateComponent);
     if (!actorTranslateComponent) return;
-    this.actorMovedSubscription = actorTranslateComponent.actorMoved.subscribe(() => {
+    this.actorMovedSubscription = actorTranslateComponent.actorMovedLogicalPosition.subscribe(() => {
       this.updateOwnerUiElementPosition();
     });
   }

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/representable-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/representable-component.ts
@@ -42,7 +42,7 @@ export class RepresentableComponent {
       this._logicalWorldTransform = { x: 0, y: 0, z: 0 }; // default to origin if transform is not available
       console.warn("RepresentableComponent: GameObject transform is not available, bounds may not be accurate.");
     }
-    this.ensureBoundArePrepared();
+    this.ensureBoundPrepared();
   }
 
   private refreshBounds(): void {
@@ -66,7 +66,7 @@ export class RepresentableComponent {
    * We need to store actors initial bounds, as bounds may change during animation playback due to different sprite dimensions.
    * See #374 for more details.
    */
-  private ensureBoundArePrepared() {
+  private ensureBoundPrepared() {
     if (this._actorBounds) return;
     const centerRelativeToOrigin = this.renderedWorldTransform;
     const bounds = getGameObjectBoundsRaw(this.gameObject);
@@ -111,11 +111,11 @@ export class RepresentableComponent {
       x: worldPosition.x,
       y: worldPosition.y - worldPosition.z // adjust y by z offset
     } satisfies Vector2Simple;
-    this.ensureBoundArePrepared();
+    this.ensureBoundPrepared();
     this.refreshBounds();
   }
 
-  set renderedWorldTransform(worldPosition: Vector2Simple) {
+  private set renderedWorldTransform(worldPosition: Vector2Simple) {
     const transformComponent = this.gameObject as unknown as Phaser.GameObjects.Components.Transform;
     if (!transformComponent.hasTransformComponent) return;
     // Update the game object position based on the new world transform

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/representable-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/representable-component.ts
@@ -1,5 +1,7 @@
 import { Vector2Simple, Vector3Simple } from "@fuzzy-waddle/api-interfaces";
 import { getGameObjectBoundsRaw, getGameObjectVisibility, onObjectReady } from "../../../data/game-object-helper";
+import { getActorComponent } from "../../../data/actor-component";
+import { FlightComponent } from "./flight-component";
 
 interface ActorInitialBounds {
   topLeft: Vector2Simple;
@@ -98,6 +100,15 @@ export class RepresentableComponent {
     this.refreshBounds();
   }
 
+  /**
+   * get z + flight height
+   */
+  getActualLogicalZ(logicalWorldTransform: Vector3Simple): number {
+    const logicalZ = logicalWorldTransform.z;
+    const flightHeight = getActorComponent(this.gameObject, FlightComponent)?.flightDefinition?.height ?? 0;
+    return logicalZ + flightHeight;
+  }
+
   get logicalWorldTransform(): Vector3Simple {
     if (!this._logicalWorldTransform) {
       this.setTransformInitially();
@@ -109,7 +120,7 @@ export class RepresentableComponent {
     this._logicalWorldTransform = worldPosition;
     this.renderedWorldTransform = {
       x: worldPosition.x,
-      y: worldPosition.y - worldPosition.z // adjust y by z offset
+      y: worldPosition.y - this.getActualLogicalZ(worldPosition) // adjust y by z offset
     } satisfies Vector2Simple;
     this.ensureBoundPrepared();
     this.refreshBounds();

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/selectable-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/selectable-component.ts
@@ -2,7 +2,7 @@ import GameObject = Phaser.GameObjects.GameObject;
 import {
   getGameObjectBounds,
   getGameObjectDepth,
-  getGameObjectTransform,
+  getGameObjectRenderedTransform,
   onObjectReady
 } from "../../../data/game-object-helper";
 import { BehaviorSubject, Subscription } from "rxjs";
@@ -43,7 +43,7 @@ export class SelectableComponent {
   private subscribeActorMove() {
     const actorTranslateComponent = getActorComponent(this.gameObject, ActorTranslateComponent);
     if (!actorTranslateComponent) return;
-    this.actorMovedSubscription = actorTranslateComponent.actorMoved.subscribe(this.update);
+    this.actorMovedSubscription = actorTranslateComponent.actorMovedLogicalPosition.subscribe(this.update);
   }
 
   private createSelectionCircle() {
@@ -79,11 +79,14 @@ export class SelectableComponent {
     this.setDepth();
   };
 
+  /**
+   * sets selection circle position based on the game object's rendered transform.
+   */
   private setPosition() {
-    const transform = getGameObjectTransform(this.gameObject);
-    if (!transform) throw new Error("Transform not found");
-    if (transform.x === undefined || transform.y === undefined) return;
-    this.selectionCircle.setPosition(transform.x, transform.y);
+    const renderedTransform = getGameObjectRenderedTransform(this.gameObject);
+    if (!renderedTransform) throw new Error("Transform not found");
+    if (renderedTransform.x === undefined || renderedTransform.y === undefined) return;
+    this.selectionCircle.setPosition(renderedTransform.x, renderedTransform.y);
   }
 
   private setDepth() {

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/walkable-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/walkable-component.ts
@@ -1,5 +1,6 @@
 import GameObject = Phaser.GameObjects.GameObject;
 import { getActorComponent } from "../../../data/actor-component";
+import { NavigationService } from "../../../scenes/services/navigation.service";
 
 export interface WalkablePath {
   top?: boolean;
@@ -99,6 +100,7 @@ export class WalkableComponent {
 
   allowWalkablePath(approachableFrom: Partial<WalkablePath>) {
     this.walkablePath = approachableFrom;
+    this.gameObject.scene.events.emit(NavigationService.UpdateNavigationEvent);
   }
 
   get walkablePathDefinition(): WalkablePath {

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/walkable-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/walkable-component.ts
@@ -4,7 +4,13 @@ import { getActorComponent } from "../../../data/actor-component";
 export interface WalkableDefinition {
   shrinkPathToRight?: number;
   shrinkPathToLeft?: number;
+  /**
+   * The height (in px) at which units should stand when on this object (e.g., stairs, wall, watchtower).
+   * For stairs, this could be the middle height; for a watchtower, the platform height, etc.
+   */
+  walkableHeight?: number;
 }
+
 export class WalkableComponent {
   constructor(
     private readonly gameObject: GameObject,
@@ -20,5 +26,13 @@ export class WalkableComponent {
     const shrinkPathToLeft = walkableComponent.walkableDefinition.shrinkPathToLeft ?? 0;
     const shrinkY = shrinkPathToLeft / 2;
     return { shrinkX, shrinkY };
+  }
+
+  /**
+   * Returns the height (in px) at which units should stand on this walkable object.
+   * Defaults to 0 if not set.
+   */
+  getDestinationHeight(): number {
+    return this.walkableDefinition.walkableHeight ?? 0;
   }
 }

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/walkable-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/walkable-component.ts
@@ -50,15 +50,14 @@ export interface WalkableDefinition {
 
 export class WalkableComponent {
   private walkablePath: WalkablePath = {
-    // todo should be by default false
-    top: true,
-    bottom: true,
-    left: true,
-    right: true,
-    topLeft: true,
-    topRight: true,
-    bottomLeft: true,
-    bottomRight: true
+    top: false,
+    bottom: false,
+    left: false,
+    right: false,
+    topLeft: false,
+    topRight: false,
+    bottomLeft: false,
+    bottomRight: false
   } satisfies WalkablePath;
   constructor(
     private readonly gameObject: GameObject,

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/walkable-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/walkable-component.ts
@@ -11,6 +11,23 @@ export interface WalkablePath {
   bottomLeft?: boolean;
   bottomRight?: boolean;
 }
+
+/**
+ * Wall:
+ *   walkableHeight: 64,
+ *   exitHeight: 64,
+ *   // can be accessed from the stairs
+ *   acceptMinimumHeight: 64
+ * WatchTower:
+ *   walkableHeight: 128,
+ *   exitHeight: 128,
+ *   // can be accessed from the stairs or a wall
+ *   acceptMinimumHeight: 64
+ * Stairs:
+ *   walkableHeight: 32,
+ *   exitHeight: 64,
+ *   acceptMinimumHeight: 0
+ */
 export interface WalkableDefinition {
   shrinkPathToRight?: number;
   shrinkPathToLeft?: number;
@@ -19,6 +36,16 @@ export interface WalkableDefinition {
    * For stairs, this could be the middle height; for a watchtower, the platform height, etc.
    */
   walkableHeight?: number;
+
+  /**
+   * Height that is used when moving to different levels - for example from stairs to a wall or watchtower
+   */
+  exitHeight?: number;
+  /**
+   * Height that responds to exitHeight when moving to different levels - for example from stairs to a wall or watchtower
+   * For example stairs -> watchTower or wall--> watchTower
+   */
+  acceptMinimumHeight?: number;
 }
 
 export class WalkableComponent {

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/walkable-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/walkable-component.ts
@@ -49,6 +49,9 @@ export interface WalkableDefinition {
 }
 
 export class WalkableComponent {
+  /**
+   * The walkable path definition that indicates from which sides this object can be approached.
+   */
   private walkablePath: WalkablePath = {
     top: false,
     bottom: false,

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/walkable-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/walkable-component.ts
@@ -1,6 +1,16 @@
 import GameObject = Phaser.GameObjects.GameObject;
 import { getActorComponent } from "../../../data/actor-component";
 
+export interface WalkablePath {
+  top?: boolean;
+  bottom?: boolean;
+  left?: boolean;
+  right?: boolean;
+  topLeft?: boolean;
+  topRight?: boolean;
+  bottomLeft?: boolean;
+  bottomRight?: boolean;
+}
 export interface WalkableDefinition {
   shrinkPathToRight?: number;
   shrinkPathToLeft?: number;
@@ -12,6 +22,16 @@ export interface WalkableDefinition {
 }
 
 export class WalkableComponent {
+  private walkablePath: WalkablePath = {
+    top: true,
+    bottom: true,
+    left: true,
+    right: true,
+    topLeft: true,
+    topRight: true,
+    bottomLeft: true,
+    bottomRight: true
+  } satisfies WalkablePath;
   constructor(
     private readonly gameObject: GameObject,
     public readonly walkableDefinition: WalkableDefinition
@@ -34,5 +54,9 @@ export class WalkableComponent {
    */
   getDestinationHeight(): number {
     return this.walkableDefinition.walkableHeight ?? 0;
+  }
+
+  allowWalkablePath(approachableFrom: Partial<WalkablePath>) {
+    this.walkablePath = approachableFrom;
   }
 }

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/walkable-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/walkable-component.ts
@@ -12,6 +12,17 @@ export interface WalkablePath {
   bottomRight?: boolean;
 }
 
+export enum WalkablePathDirection {
+  Top = "top",
+  Bottom = "bottom",
+  Left = "left",
+  Right = "right",
+  TopLeft = "topLeft",
+  TopRight = "topRight",
+  BottomLeft = "bottomLeft",
+  BottomRight = "bottomRight"
+}
+
 /**
  * Wall:
  *   walkableHeight: 64,
@@ -96,15 +107,14 @@ export class WalkableComponent {
 
   get accessibleFromAllSides(): boolean {
     return (
-      (this.walkablePath.top &&
-        this.walkablePath.bottom &&
-        this.walkablePath.left &&
-        this.walkablePath.right &&
-        this.walkablePath.topLeft &&
-        this.walkablePath.topRight &&
-        this.walkablePath.bottomLeft &&
-        this.walkablePath.bottomRight) ??
-      true
+      (this.walkablePath.top ?? false) &&
+      (this.walkablePath.bottom ?? false) &&
+      (this.walkablePath.left ?? false) &&
+      (this.walkablePath.right ?? false) &&
+      (this.walkablePath.topLeft ?? false) &&
+      (this.walkablePath.topRight ?? false) &&
+      (this.walkablePath.bottomLeft ?? false) &&
+      (this.walkablePath.bottomRight ?? false)
     );
   }
 }

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/walkable-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/walkable-component.ts
@@ -23,6 +23,7 @@ export interface WalkableDefinition {
 
 export class WalkableComponent {
   private walkablePath: WalkablePath = {
+    // todo should be by default false
     top: true,
     bottom: true,
     left: true,

--- a/apps/client/src/app/probable-waffle/game/entity/actor/components/walkable-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/actor/components/walkable-component.ts
@@ -59,4 +59,22 @@ export class WalkableComponent {
   allowWalkablePath(approachableFrom: Partial<WalkablePath>) {
     this.walkablePath = approachableFrom;
   }
+
+  get walkablePathDefinition(): WalkablePath {
+    return this.walkablePath;
+  }
+
+  get accessibleFromAllSides(): boolean {
+    return (
+      (this.walkablePath.top &&
+        this.walkablePath.bottom &&
+        this.walkablePath.left &&
+        this.walkablePath.right &&
+        this.walkablePath.topLeft &&
+        this.walkablePath.topRight &&
+        this.walkablePath.bottomLeft &&
+        this.walkablePath.bottomRight) ??
+      true
+    );
+  }
 }

--- a/apps/client/src/app/probable-waffle/game/entity/building/production/production-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/building/production/production-component.ts
@@ -16,7 +16,8 @@ import { getSceneService } from "../../../scenes/components/scene-component-help
 import { SceneActorCreator } from "../../../scenes/components/scene-actor-creator";
 import {
   getGameObjectBounds,
-  getGameObjectTransform,
+  getGameObjectLogicalTransform,
+  getGameObjectRenderedTransform,
   getGameObjectVisibility,
   onObjectReady
 } from "../../../data/game-object-helper";
@@ -258,9 +259,8 @@ export class ProductionComponent {
 
     // spawn gameObject
 
-    const transform = getGameObjectTransform(this.gameObject);
-    if (!transform) throw new Error("Transform not found");
-    const tilePlacementData = { x: transform.x, y: transform.y, z: transform.z } satisfies Vector3Simple;
+    const logicalTransform = getGameObjectLogicalTransform(this.gameObject);
+    if (!logicalTransform) throw new Error("Transform not found");
 
     // offset spawn position
     const bounds = getGameObjectBounds(this.gameObject);
@@ -268,23 +268,21 @@ export class ProductionComponent {
     const { width, height } = bounds;
 
     const spawnPosition: Vector3Simple = {
-      x: tilePlacementData.x + width / 2,
-      y: tilePlacementData.y + height / 4,
-      z: tilePlacementData.z
+      x: logicalTransform.x + width / 2,
+      y: logicalTransform.y + height / 4,
+      z: logicalTransform.z
     };
 
     const originalOwner = this.ownerComponent.getOwner();
 
     const actorDefinition = {
       name: actorName,
-      x: spawnPosition.x,
-      y: spawnPosition.y,
-      ...(spawnPosition.z && { z: spawnPosition.z }),
+      logicalWorldTransform: spawnPosition,
       ...(originalOwner && { owner: originalOwner }),
       constructionSite: {
         state: ConstructionStateEnum.Finished
       }
-    } as ActorDefinition;
+    } satisfies ActorDefinition;
 
     const sceneActorCreator = getSceneService(this.gameObject.scene, SceneActorCreator);
     if (!sceneActorCreator) throw new Error("SceneActorCreator not found");

--- a/apps/client/src/app/probable-waffle/game/entity/character/ai/behavior/tasks/move-to.task.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/character/ai/behavior/tasks/move-to.task.ts
@@ -2,14 +2,14 @@ import { ITask, TaskData_old, TaskResultType } from "./task.interface";
 import { PawnAiControllerComponentOld } from "../../../../../world/managers/controllers/pawn-ai-controller-component-old";
 import { Vector3Simple } from "@fuzzy-waddle/api-interfaces";
 import { getActorComponent } from "../../../../../data/actor-component";
-import { getGameObjectTransform } from "../../../../../data/game-object-helper";
+import { getGameObjectRenderedTransform } from "../../../../../data/game-object-helper";
 
 export class MoveToTask implements ITask {
   executeTask(taskData: TaskData_old): TaskResultType {
     const targetActor = taskData.blackboard.targetGameObject;
     let targetLocation = taskData.blackboard.targetLocation;
     if (targetActor) {
-      const transform = getGameObjectTransform(targetActor);
+      const transform = getGameObjectRenderedTransform(targetActor);
       if (!transform) throw new Error("Transform not found");
       targetLocation = { x: transform.x, y: transform.y, z: transform.z } satisfies Vector3Simple;
     }

--- a/apps/client/src/app/probable-waffle/game/entity/combat/components/health-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/combat/components/health-component.ts
@@ -142,8 +142,12 @@ export class HealthComponent {
     switch (this.healthDefinition.physicalState) {
       case ActorPhysicalType.Biological:
         if (this.actorTranslateComponent) {
-          const transform = this.actorTranslateComponent.currentTileWorldXY;
-          const effect = EffectsAnims.createAndPlayBloodAnimation(this.gameObject.scene, transform.x, transform.y);
+          const renderedTransform = this.actorTranslateComponent.renderedTransform;
+          const effect = EffectsAnims.createAndPlayBloodAnimation(
+            this.gameObject.scene,
+            renderedTransform.x,
+            renderedTransform.y
+          );
           const gameObjectDepth = getGameObjectDepth(this.gameObject);
           if (gameObjectDepth) {
             effect.setDepth(gameObjectDepth + 1);

--- a/apps/client/src/app/probable-waffle/game/entity/combat/components/health-ui-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/combat/components/health-ui-component.ts
@@ -69,7 +69,7 @@ export class HealthUiComponent {
   private subscribeActorMove() {
     const actorTranslateComponent = getActorComponent(this.gameObject, ActorTranslateComponent);
     if (!actorTranslateComponent) return;
-    this.actorMovedSubscription = actorTranslateComponent.actorMoved.subscribe(() => {
+    this.actorMovedSubscription = actorTranslateComponent.actorMovedLogicalPosition.subscribe(() => {
       this.updateElementPosition();
     });
   }

--- a/apps/client/src/app/probable-waffle/game/entity/economy/resource/resource-source-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/economy/resource/resource-source-component.ts
@@ -1,8 +1,8 @@
-import { ResourceType, Vector3Simple } from "@fuzzy-waddle/api-interfaces";
+import { ResourceType, Vector2Simple, Vector3Simple } from "@fuzzy-waddle/api-interfaces";
 import { ContainerComponent } from "../../building/container-component";
 import { Subject } from "rxjs";
 import { getActorComponent } from "../../../data/actor-component";
-import { getGameObjectTransform } from "../../../data/game-object-helper";
+import { getGameObjectRenderedTransform } from "../../../data/game-object-helper";
 import GameObject = Phaser.GameObjects.GameObject;
 
 export type ResourceSourceDefinition = {
@@ -81,15 +81,18 @@ export class ResourceSourceComponent {
     // check if we're depleted
     if (this.currentResources <= 0) {
       this.onDepleted.next(this.gameObject);
-      const transform = getGameObjectTransform(this.gameObject);
+      const renderedTransform = getGameObjectRenderedTransform(this.gameObject);
       this.gameObject.destroy();
-      this.spawnTreeTrunk(transform);
+      this.spawnTreeTrunk(renderedTransform);
     }
     return gatheredAmount;
   }
 
-  private spawnTreeTrunk(transform: Vector3Simple | null) {
-    if (!transform) return;
+  /**
+   * Spawns a tree trunk image at the given rendered transform position.
+   */
+  private spawnTreeTrunk(renderedTransform: Vector2Simple | null) {
+    if (!renderedTransform) return;
     if (!this.scene) return;
 
     let texture = null;
@@ -114,7 +117,7 @@ export class ResourceSourceComponent {
     }
     if (!texture || !frame) return;
 
-    this.depletedImage = this.scene.add.image(transform.x, transform.y, texture, frame);
+    this.depletedImage = this.scene.add.image(renderedTransform.x, renderedTransform.y, texture, frame);
   }
 
   canGathererEnter(gatherer: GameObject): boolean {

--- a/apps/client/src/app/probable-waffle/game/entity/systems/action.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/action.system.ts
@@ -23,6 +23,8 @@ import { getSceneService } from "../../scenes/components/scene-component-helpers
 import { DebuggingService } from "../../scenes/services/DebuggingService";
 import { ContainableComponent } from "../actor/components/containable-component";
 import { AudioActorComponent } from "../actor/components/audio-actor-component";
+import { WalkableComponent } from "../actor/components/walkable-component";
+import { FlightComponent } from "../actor/components/flight-component";
 
 export class ActionSystem {
   private playerChangedSubscription?: Subscription;
@@ -95,6 +97,13 @@ export class ActionSystem {
       if (selfPlayerNumber === targetPlayerNumber) {
         // ally
 
+        const targetIsWalkable = getActorComponent(targetGameObject, WalkableComponent);
+        const selfHasFlying = getActorComponent(this.gameObject, FlightComponent);
+        if (targetIsWalkable && !selfHasFlying) {
+          // target is walkable and self is not flying
+          return new OrderData(OrderType.Move, { targetGameObject });
+        }
+
         const targetIsBuilding = getActorComponent(targetGameObject, ConstructionSiteComponent);
         if (targetIsBuilding) {
           // target is building
@@ -159,6 +168,7 @@ export class ActionSystem {
           if (selfContainableComponent) {
             // self is containable
 
+            console.warn("todo - this is not yet supported in player-pawn-ai-controller"); // todo
             return new OrderData(OrderType.EnterContainer, { targetGameObject });
           }
         }

--- a/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
@@ -286,6 +286,7 @@ export class MovementSystem {
         targets: logicalTransform,
         x: tileWorldXY.x,
         y: tileWorldXY.y,
+        z: 0,
         duration: tileStepDuration,
         onComplete: async () => {
           try {

--- a/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
@@ -206,16 +206,9 @@ export class MovementSystem {
           : undefined;
 
         let newZ = 0;
-        const flightComponent = getActorComponent(this.gameObject, FlightComponent);
-        if (flightComponent && flightComponent.flightDefinition?.height) {
-          // todo newZ = flightComponent.flightDefinition.height;
-          console.log("z offset for flying actors is not implemented yet"); // todo
-        } else {
-          // If not flying, check for walkable component
-          const walkableComponent = getActorComponent(destinationGameObject, WalkableComponent);
-          if (walkableComponent && walkableComponent.getDestinationHeight) {
-            newZ += walkableComponent.getDestinationHeight();
-          }
+        const walkableComponent = getActorComponent(destinationGameObject, WalkableComponent);
+        if (walkableComponent && walkableComponent.getDestinationHeight) {
+          newZ += walkableComponent.getDestinationHeight();
         }
         const newRenderWorldTransform = {
           x: tileWorldXY.x,
@@ -354,12 +347,7 @@ export class MovementSystem {
         return;
       }
 
-      let newZ = 0;
-      const flightComponent = getActorComponent(this.gameObject, FlightComponent);
-      if (flightComponent && flightComponent.flightDefinition?.height) {
-        // todo newZ = flightComponent.flightDefinition.height;
-        console.log("z offset for flying actors is not implemented yet"); // todo
-      }
+      const newZ = 0;
       const newRenderWWorldTransform = {
         x: tileWorldXY.x,
         y: tileWorldXY.y - newZ,

--- a/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
@@ -366,7 +366,7 @@ export class MovementSystem {
       this.onMovementStart(newCoords, pathMoveConfig);
       this._currentTween = this.gameObject.scene.tweens.add({
         targets: this.gameObject,
-        x: newCoords,
+        x: newCoords.x,
         y: newCoords.y,
         z: newCoords.z,
         duration:

--- a/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
@@ -546,22 +546,6 @@ export async function moveGameObjectToRandomTileInNavigableRadius(
   );
 }
 
-export function getGameObjectDirection(
-  gameObject: Phaser.GameObjects.GameObject,
-  newTile: Vector2Simple
-): IsoDirection | undefined {
-  const currentTile = getGameObjectCurrentTile(gameObject);
-  if (!currentTile) return;
-
-  const navigationService = getSceneService(gameObject.scene, NavigationService);
-  if (!navigationService) return;
-
-  const currentTileWorldXY = navigationService.getTileWorldCenter(currentTile);
-  const newTileWorldXY = navigationService.getTileWorldCenter(newTile);
-
-  return getGameObjectDirectionBetweenTiles(currentTileWorldXY, newTileWorldXY);
-}
-
 export function getGameObjectDirectionBetweenTiles(
   oldTileWorldXY: Vector2Simple | undefined,
   newTileWorldXY: Vector2Simple | undefined

--- a/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
@@ -34,6 +34,7 @@ import {
 import { OwnerComponent } from "../actor/components/owner-component";
 import { AnimationActorComponent } from "../actor/components/animation-actor-component";
 import { FlightComponent } from "../actor/components/flight-component";
+import { WalkableComponent } from "../actor/components/walkable-component";
 import Tween = Phaser.Tweens.Tween;
 import GameObject = Phaser.GameObjects.GameObject;
 
@@ -211,6 +212,12 @@ export class MovementSystem {
         const flightComponent = getActorComponent(this.gameObject, FlightComponent);
         if (flightComponent && flightComponent.flightDefinition?.height) {
           adjustedY -= flightComponent.flightDefinition.height;
+        } else {
+          // If not flying, check for walkable component
+          const walkableComponent = getActorComponent(this.gameObject, WalkableComponent);
+          if (walkableComponent && walkableComponent.getDestinationHeight) {
+            adjustedY -= walkableComponent.getDestinationHeight();
+          }
         }
         this.onMovementStart({ x: tileWorldXY.x, y: adjustedY }, pathMoveConfig);
         const actorTranslateComponent = getActorComponent(this.gameObject, ActorTranslateComponent);
@@ -343,6 +350,12 @@ export class MovementSystem {
       const flightComponent = getActorComponent(this.gameObject, FlightComponent);
       if (flightComponent && flightComponent.flightDefinition?.height) {
         adjustedY -= flightComponent.flightDefinition.height;
+      } else {
+        // If not flying, check for walkable component
+        const walkableComponent = getActorComponent(this.gameObject, WalkableComponent);
+        if (walkableComponent && walkableComponent.getDestinationHeight) {
+          adjustedY -= walkableComponent.getDestinationHeight();
+        }
       }
       this.onMovementStart({ x: tileWorldXY.x, y: adjustedY }, pathMoveConfig);
       this._currentTween = this.gameObject.scene.tweens.add({

--- a/apps/client/src/app/probable-waffle/game/library/gameplay-library.ts
+++ b/apps/client/src/app/probable-waffle/game/library/gameplay-library.ts
@@ -2,7 +2,7 @@ import { Actor } from "../entity/actor/actor";
 import { TransformComponent } from "../entity/actor/components/transformable-component";
 import { getActorComponent } from "../data/actor-component";
 import { OwnerComponent } from "../entity/actor/components/owner-component";
-import { getGameObjectCurrentTile, getGameObjectTransform } from "../data/game-object-helper";
+import { getGameObjectCurrentTile } from "../data/game-object-helper";
 import { Vector3Simple } from "@fuzzy-waddle/api-interfaces";
 import GameObject = Phaser.GameObjects.GameObject;
 
@@ -51,32 +51,11 @@ export class GameplayLibrary {
     return distance;
   }
 
-  static getWorldDistanceBetweenGameObjects(actor1: GameObject, actor2: GameObject): number | null {
-    if (actor1 === actor2) return 0;
-    const actor1Transform = getGameObjectTransform(actor1);
-    if (!actor1Transform) return null;
-    const actor1Position = {
-      x: actor1Transform.x,
-      y: actor1Transform.y,
-      z: actor1Transform.z
-    } satisfies Vector3Simple;
-
-    const actor2Transform = getGameObjectTransform(actor2);
-    if (!actor2Transform) return null;
-    const actor2Position = {
-      x: actor2Transform.x,
-      y: actor2Transform.y,
-      z: actor2Transform.z
-    } satisfies Vector3Simple;
-
-    // noinspection UnnecessaryLocalVariableJS
-    const distance = Math.sqrt(
-      Math.pow(actor1Position.x - actor2Position.x, 2) +
-        Math.pow(actor1Position.y - actor2Position.y, 2) +
-        Math.pow(actor1Position.z - actor2Position.z, 2)
-    );
-
-    return distance;
+  static distance3D(a: Vector3Simple, b: Vector3Simple): number {
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const dz = b.z - a.z;
+    return Math.sqrt(dx * dx + dy * dy + dz * dz);
   }
 
   static getTileDistanceBetweenGameObjects(actor1: GameObject, actor2: GameObject): number | null {

--- a/apps/client/src/app/probable-waffle/game/prefabs/animals/Badger.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/animals/Badger.ts
@@ -101,7 +101,7 @@ export default class Badger extends Phaser.GameObjects.Sprite {
     this.animationActorComponent?.playCustomAnimation("tunnel");
 
     this.movementSystem
-      ?.moveToLocation({ x: tileXY.x, y: tileXY.y, z: 0 }, {
+      ?.moveToLocationByFollowingStaticPath({ x: tileXY.x, y: tileXY.y, z: 0 }, {
         ignoreAnimations: true // we're overriding move animations here
       } satisfies PathMoveConfig)
       .then((success) => {

--- a/apps/client/src/app/probable-waffle/game/prefabs/buildings/misc/RallyPoint.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/buildings/misc/RallyPoint.ts
@@ -75,12 +75,12 @@ export default class RallyPoint extends Phaser.GameObjects.Image {
     if (!movementSystem) return;
     if (this.tileVec3) {
       // noinspection JSIgnoredPromiseFromCall
-      movementSystem.moveToLocation(this.tileVec3);
+      movementSystem.moveToLocationByFollowingStaticPath(this.tileVec3);
       return;
     }
     if (this.actor) {
       // noinspection JSIgnoredPromiseFromCall
-      movementSystem.moveToActor(this.actor);
+      movementSystem.moveToActorByAdjustingPathDynamically(this.actor);
     }
   }
 

--- a/apps/client/src/app/probable-waffle/game/prefabs/buildings/misc/RallyPoint.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/buildings/misc/RallyPoint.ts
@@ -12,7 +12,7 @@ import { GameObjects } from "phaser";
 import { getActorComponent } from "../../../data/actor-component";
 import { SelectableComponent } from "../../../entity/actor/components/selectable-component";
 import { Subscription } from "rxjs";
-import { getGameObjectTransform } from "../../../data/game-object-helper";
+import { getGameObjectRenderedTransform } from "../../../data/game-object-helper";
 import { SharedActorActionsRallyPointSound } from "../../../sfx/SharedActorActionsSfx";
 import { getSceneService } from "../../../scenes/components/scene-component-helpers";
 import { AudioService } from "../../../scenes/services/audio.service";
@@ -117,7 +117,7 @@ export default class RallyPoint extends Phaser.GameObjects.Image {
     if (!this.owner) return;
     if (!this.lineGraphics) return;
     if (!this.visible) return;
-    const ownerTransform = getGameObjectTransform(this.owner);
+    const ownerTransform = getGameObjectRenderedTransform(this.owner);
     if (!ownerTransform) return;
 
     this.lineGraphics.clear();

--- a/apps/client/src/app/probable-waffle/game/prefabs/buildings/tivara/stairs/Stairs.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/buildings/tivara/stairs/Stairs.ts
@@ -5,9 +5,7 @@
 import StairsTopLeft from "./StairsTopLeft";
 /* START-USER-IMPORTS */
 import { ObjectNames } from "@fuzzy-waddle/api-interfaces";
-import {
-  ConstructionGameObjectInterfaceComponent
-} from "../../../../entity/building/construction/construction-game-object-interface-component";
+import { ConstructionGameObjectInterfaceComponent } from "../../../../entity/building/construction/construction-game-object-interface-component";
 import { onObjectReady } from "../../../../data/game-object-helper";
 import { throttle } from "../../../../library/throttle";
 import { getNeighboursByTypes } from "../../../../data/tile-map-helpers";
@@ -18,6 +16,8 @@ import StairsTopRight from "./StairsTopRight";
 import StairsBottomLeft from "./StairsBottomLeft";
 import StairsBottomRight from "./StairsBottomRight";
 import { setActorData } from "../../../../data/actor-data";
+import { getActorComponent } from "../../../../data/actor-component";
+import { WalkablePath, WalkableComponent } from "../../../../entity/actor/components/walkable-component";
 /* END-USER-IMPORTS */
 
 export default class Stairs extends Phaser.GameObjects.Container {
@@ -84,6 +84,42 @@ export default class Stairs extends Phaser.GameObjects.Container {
       this.add(this.stairs);
     } else {
       throw new Error("Stairs type not found");
+    }
+    const walkableComponent = getActorComponent(this, WalkableComponent);
+    if (walkableComponent) {
+      const walkablePath = this.getWalkablePath(stairsType);
+      walkableComponent.allowWalkablePath(walkablePath);
+    }
+  }
+
+  private getWalkablePath(stairsType: StairsType): WalkablePath {
+    switch (stairsType) {
+      case StairsType.TopLeft:
+        return {
+          right: true,
+          bottomRight: true,
+          bottom: true
+        };
+      case StairsType.TopRight:
+        return {
+          left: true,
+          bottomLeft: true,
+          bottom: true
+        };
+      case StairsType.BottomLeft:
+        return {
+          top: true,
+          topRight: true,
+          right: true
+        };
+      case StairsType.BottomRight:
+        return {
+          top: true,
+          topLeft: true,
+          left: true
+        };
+      default:
+        return {};
     }
   }
 

--- a/apps/client/src/app/probable-waffle/game/prefabs/buildings/tivara/stairs/Stairs.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/buildings/tivara/stairs/Stairs.ts
@@ -68,7 +68,10 @@ export default class Stairs extends Phaser.GameObjects.Container {
   /* START-USER-CODE */
   name = ObjectNames.Stairs;
   private stairs?: Phaser.GameObjects.GameObject;
+  private currentStairsType?: StairsType;
   updateStairs(stairsType: StairsType) {
+    if (this.currentStairsType === stairsType) return;
+    this.currentStairsType = stairsType;
     this.stairs?.destroy();
     const stairClasses = {
       [StairsType.TopLeft]: StairsTopLeft,

--- a/apps/client/src/app/probable-waffle/game/prefabs/buildings/tivara/wall/Wall.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/buildings/tivara/wall/Wall.ts
@@ -75,8 +75,10 @@ export default class Wall extends Phaser.GameObjects.Container {
   name = ObjectNames.Wall;
 
   private wall?: Phaser.GameObjects.GameObject;
-
+  private currentWallType?: WallType;
   updateWall(wallType: WallType) {
+    if (this.currentWallType === wallType) return;
+    this.currentWallType = wallType;
     this.wall?.destroy();
 
     const wallClasses = {

--- a/apps/client/src/app/probable-waffle/game/prefabs/buildings/tivara/wall/Wall.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/buildings/tivara/wall/Wall.ts
@@ -13,9 +13,7 @@ import WallTopLeft from "./WallTopLeft";
 import WallTopRight from "./WallTopRight";
 import WallBottomLeft from "./WallBottomLeft";
 import WallBottomRight from "./WallBottomRight";
-import {
-  ConstructionGameObjectInterfaceComponent
-} from "../../../../entity/building/construction/construction-game-object-interface-component";
+import { ConstructionGameObjectInterfaceComponent } from "../../../../entity/building/construction/construction-game-object-interface-component";
 import WallBottomLeftBottomRight from "./WallBottomLeftBottomRight";
 import WallTopLeftTopRight from "./WallTopLeftTopRight";
 import WallFull from "./WallFull";
@@ -30,6 +28,8 @@ import Stairs from "../stairs/Stairs";
 import { getNeighboursByTypes } from "../../../../data/tile-map-helpers";
 import { TilemapComponent } from "../../../../scenes/components/tilemap.component";
 import { setActorData } from "../../../../data/actor-data";
+import { getActorComponent } from "../../../../data/actor-component";
+import { WalkableComponent, WalkablePath } from "../../../../entity/actor/components/walkable-component";
 /* END-USER-IMPORTS */
 
 export default class Wall extends Phaser.GameObjects.Container {
@@ -105,6 +105,60 @@ export default class Wall extends Phaser.GameObjects.Container {
       this.add(this.wall);
     } else {
       throw new Error("Wall type not found");
+    }
+
+    const walkableComponent = getActorComponent(this, WalkableComponent);
+    if (walkableComponent) {
+      const walkablePath = this.getWalkablePath(wallType);
+      walkableComponent.allowWalkablePath(walkablePath);
+    }
+  }
+
+  private getWalkablePath(wallType: WallType): WalkablePath {
+    switch (wallType) {
+      case WallType.TopRightBottomRight:
+        return { topLeft: true, left: true, bottomLeft: true };
+      case WallType.TopRightBottomLeft:
+        return { topLeft: true, bottomRight: true };
+      case WallType.TopLeftBottomRight:
+        return { topRight: true, bottomLeft: true };
+      case WallType.TopLeftBottomLeft:
+        return { topRight: true, right: true, bottomRight: true };
+      case WallType.Empty:
+        return {
+          top: true,
+          bottom: true,
+          left: true,
+          right: true,
+          topLeft: true,
+          topRight: true,
+          bottomLeft: true,
+          bottomRight: true
+        };
+      case WallType.Full:
+        return {};
+      case WallType.TopLeft:
+        return { topRight: true, right: true, bottomRight: true, bottom: true, bottomLeft: true };
+      case WallType.TopRight:
+        return { topLeft: true, left: true, bottomLeft: true, bottom: true, bottomRight: true };
+      case WallType.BottomLeft:
+        return { topLeft: true, top: true, topRight: true, right: true, bottomRight: true };
+      case WallType.BottomRight:
+        return { topRight: true, top: true, topLeft: true, left: true, bottomLeft: true };
+      case WallType.TopLeftTopRight:
+        return { bottomLeft: true, bottom: true, bottomRight: true };
+      case WallType.BottomLeftBottomRight:
+        return { topRight: true, top: true, topLeft: true };
+      case WallType.TopLeftTopRightBottomLeft:
+        return { bottomRight: true };
+      case WallType.TopRightBottomLeftBottomRight:
+        return { topLeft: true };
+      case WallType.TopLeftTopRightBottomRight:
+        return { bottomLeft: true };
+      case WallType.TopLeftBottomLeftBottomRight:
+        return { topRight: true };
+      default:
+        return {};
     }
   }
 

--- a/apps/client/src/app/probable-waffle/game/prefabs/gui/buttons/ActorActions.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/gui/buttons/ActorActions.ts
@@ -287,7 +287,7 @@ export default class ActorActions extends Phaser.GameObjects.Container {
             if (!movementSystem) return;
             const tileXY = await getRandomTileInNavigableRadius(actor, 10);
             if (!tileXY) return;
-            await movementSystem.moveToLocation({
+            await movementSystem.moveToLocationByFollowingStaticPath({
               x: tileXY.x,
               y: tileXY.y,
               z: 0

--- a/apps/client/src/app/probable-waffle/game/prefabs/outside/architecture/river/BridgeStone.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/outside/architecture/river/BridgeStone.ts
@@ -23,13 +23,25 @@ export default class BridgeStone extends Phaser.GameObjects.Image {
     );
 
     /* START-USER-CTR-CODE */
+    const walkableComponent = new WalkableComponent(this, { shrinkPathToRight: 4 } satisfies WalkableDefinition);
+    // TODO #387 - until this is properly implemented, we are marking the bridge as walkable from all sides
+    walkableComponent.allowWalkablePath({
+      bottomLeft: true,
+      topRight: true,
+      bottom: true,
+      bottomRight: true,
+      left: true,
+      right: true,
+      top: true,
+      topLeft: true
+    });
     setActorData(
       this,
       [
         new ObjectDescriptorComponent({
           color: 0x97a09e
         } satisfies ObjectDescriptorDefinition),
-        new WalkableComponent(this, { shrinkPathToRight: 4 } satisfies WalkableDefinition)
+        walkableComponent
       ],
       []
     );

--- a/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.scene
+++ b/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.scene
@@ -68,6 +68,21 @@
             "EditorOwner.owner_id": "1",
             "x": -192,
             "y": 592
+        },
+        {
+            "prefabId": "e858a91a-5bcf-4095-9fd3-07f98cf4415d",
+            "id": "5ada33a3-a915-4864-a290-2e1aa49ab21f",
+            "unlock": [
+                "x",
+                "y"
+            ],
+            "label": "stairs",
+            "components": [
+                "EditorOwner"
+            ],
+            "EditorOwner.owner_id": "1",
+            "x": -160,
+            "y": 624
         }
     ],
     "plainObjects": [

--- a/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.scene
+++ b/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.scene
@@ -62,7 +62,11 @@
                 "y"
             ],
             "label": "stairs",
-            "x": -224,
+            "components": [
+                "EditorOwner"
+            ],
+            "EditorOwner.owner_id": "1",
+            "x": -160,
             "y": 624
         },
         {
@@ -73,6 +77,10 @@
                 "y"
             ],
             "label": "stairs_2",
+            "components": [
+                "EditorOwner"
+            ],
+            "EditorOwner.owner_id": "1",
             "x": 32,
             "y": 752
         },
@@ -84,8 +92,57 @@
                 "y"
             ],
             "label": "wall",
+            "components": [
+                "EditorOwner"
+            ],
+            "EditorOwner.owner_id": "1",
             "x": 0,
             "y": 768
+        },
+        {
+            "prefabId": "edf32147-e546-4f6e-91ba-1720c6b75ac9",
+            "id": "e4175041-b949-424a-bfc5-bb5e44de7db8",
+            "unlock": [
+                "x",
+                "y"
+            ],
+            "label": "tivaraWorkerMale",
+            "components": [
+                "EditorOwner"
+            ],
+            "EditorOwner.owner_id": "1",
+            "x": 108,
+            "y": 786
+        },
+        {
+            "prefabId": "5f8b7bf2-30e6-4361-b3c5-7a796ee21bd3",
+            "id": "ace32f75-11be-4b55-9f23-be5ee4e6e94e",
+            "unlock": [
+                "x",
+                "y"
+            ],
+            "label": "wall_1",
+            "components": [
+                "EditorOwner"
+            ],
+            "EditorOwner.owner_id": "1",
+            "x": -32,
+            "y": 784
+        },
+        {
+            "prefabId": "5f8b7bf2-30e6-4361-b3c5-7a796ee21bd3",
+            "id": "efedada0-9a41-42d0-a956-77c4580811c9",
+            "unlock": [
+                "x",
+                "y"
+            ],
+            "label": "wall_2",
+            "components": [
+                "EditorOwner"
+            ],
+            "EditorOwner.owner_id": "1",
+            "x": -64,
+            "y": 800
         },
         {
             "prefabId": "e858a91a-5bcf-4095-9fd3-07f98cf4415d",
@@ -95,8 +152,12 @@
                 "y"
             ],
             "label": "stairs_1",
-            "x": -32,
-            "y": 784
+            "components": [
+                "EditorOwner"
+            ],
+            "EditorOwner.owner_id": "1",
+            "x": -96,
+            "y": 816
         }
     ],
     "plainObjects": [

--- a/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.scene
+++ b/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.scene
@@ -5,7 +5,7 @@
         "compilerInsertSpaces": true,
         "compilerTabSize": 2,
         "snapEnabled": true,
-        "snapWidth": 32,
+        "snapHeight": 8,
         "exportClass": true,
         "autoImport": true,
         "superClassName": "GameProbableWaffleScene",
@@ -27,21 +27,6 @@
                 "tiles",
                 "tiles_2"
             ]
-        },
-        {
-            "prefabId": "edf32147-e546-4f6e-91ba-1720c6b75ac9",
-            "id": "995e2abe-47e3-4715-85aa-ab35a85fb09f",
-            "unlock": [
-                "x",
-                "y"
-            ],
-            "label": "tivaraWorkerMale",
-            "components": [
-                "EditorOwner"
-            ],
-            "EditorOwner.owner_id": "1",
-            "x": 40,
-            "y": 650
         },
         {
             "prefabId": "f09568ca-4e05-4ddd-ba4f-3ad6c515d28b",
@@ -71,18 +56,47 @@
         },
         {
             "prefabId": "e858a91a-5bcf-4095-9fd3-07f98cf4415d",
-            "id": "5ada33a3-a915-4864-a290-2e1aa49ab21f",
+            "id": "0bf2c10c-cff0-4183-9a96-b148339e7bff",
             "unlock": [
                 "x",
                 "y"
             ],
             "label": "stairs",
-            "components": [
-                "EditorOwner"
-            ],
-            "EditorOwner.owner_id": "1",
-            "x": -160,
+            "x": -224,
             "y": 624
+        },
+        {
+            "prefabId": "e858a91a-5bcf-4095-9fd3-07f98cf4415d",
+            "id": "f87c28b2-9fb5-46d8-b7b9-35fd13ad562f",
+            "unlock": [
+                "x",
+                "y"
+            ],
+            "label": "stairs_2",
+            "x": 32,
+            "y": 752
+        },
+        {
+            "prefabId": "5f8b7bf2-30e6-4361-b3c5-7a796ee21bd3",
+            "id": "1a0c7d0f-4d01-40e1-8372-4f830017e538",
+            "unlock": [
+                "x",
+                "y"
+            ],
+            "label": "wall",
+            "x": 0,
+            "y": 768
+        },
+        {
+            "prefabId": "e858a91a-5bcf-4095-9fd3-07f98cf4415d",
+            "id": "22a8f57b-7d26-4990-9f25-b6e129042ae4",
+            "unlock": [
+                "x",
+                "y"
+            ],
+            "label": "stairs_1",
+            "x": -32,
+            "y": 784
         }
     ],
     "plainObjects": [

--- a/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.scene
+++ b/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.scene
@@ -44,21 +44,6 @@
             "y": 650
         },
         {
-            "prefabId": "ec58b20e-e04f-4bd3-840e-856ffe433f23",
-            "id": "e0b3669c-7bac-4a27-94db-c5da471f53c8",
-            "unlock": [
-                "x",
-                "y"
-            ],
-            "label": "workMill",
-            "components": [
-                "EditorOwner"
-            ],
-            "EditorOwner.owner_id": "2",
-            "x": 448,
-            "y": 736
-        },
-        {
             "prefabId": "f09568ca-4e05-4ddd-ba4f-3ad6c515d28b",
             "id": "3c9fde9f-77b3-458c-9ebb-bbe97c3a8870",
             "unlock": [
@@ -70,34 +55,19 @@
             "y": 416
         },
         {
-            "prefabId": "ec58b20e-e04f-4bd3-840e-856ffe433f23",
-            "id": "7dec28fb-7251-4ac5-a799-5fc4d59c074c",
+            "prefabId": "ec58b20e-e04f-4bd3-840e-856ffe433f37",
+            "id": "af67e67d-8537-4576-8709-2e52a49af171",
             "unlock": [
                 "x",
                 "y"
             ],
-            "label": "workMill_1",
+            "label": "watchTower",
             "components": [
                 "EditorOwner"
             ],
             "EditorOwner.owner_id": "1",
-            "x": -352,
-            "y": 576
-        },
-        {
-            "prefabId": "6c2cf0db-4461-4b32-b5d3-9882c5326e1b",
-            "id": "d5d32a63-a668-4046-952a-67a74abbafbe",
-            "unlock": [
-                "x",
-                "y"
-            ],
-            "label": "tivaraSlingshotFemale",
-            "components": [
-                "EditorOwner"
-            ],
-            "EditorOwner.owner_id": "1",
-            "x": 224,
-            "y": 560
+            "x": -192,
+            "y": 592
         }
     ],
     "plainObjects": [

--- a/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.ts
+++ b/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.ts
@@ -8,6 +8,7 @@ import WatchTower from "../prefabs/buildings/tivara/wall/WatchTower";
 import EditorOwner from "../editor-components/EditorOwner";
 import Stairs from "../prefabs/buildings/tivara/stairs/Stairs";
 import Wall from "../prefabs/buildings/tivara/wall/Wall";
+import TivaraWorkerMale from "../prefabs/characters/tivara/TivaraWorkerMale";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 
@@ -40,7 +41,7 @@ export default class MapSandbox extends GameProbableWaffleScene {
     this.add.existing(watchTower);
 
     // stairs
-    const stairs = new Stairs(this, -224, 624);
+    const stairs = new Stairs(this, -160, 624);
     this.add.existing(stairs);
 
     // stairs_2
@@ -51,13 +52,53 @@ export default class MapSandbox extends GameProbableWaffleScene {
     const wall = new Wall(this, 0, 768);
     this.add.existing(wall);
 
+    // tivaraWorkerMale
+    const tivaraWorkerMale = new TivaraWorkerMale(this, 108, 786);
+    this.add.existing(tivaraWorkerMale);
+
+    // wall_1
+    const wall_1 = new Wall(this, -32, 784);
+    this.add.existing(wall_1);
+
+    // wall_2
+    const wall_2 = new Wall(this, -64, 800);
+    this.add.existing(wall_2);
+
     // stairs_1
-    const stairs_1 = new Stairs(this, -32, 784);
+    const stairs_1 = new Stairs(this, -96, 816);
     this.add.existing(stairs_1);
 
     // watchTower (components)
     const watchTowerEditorOwner = new EditorOwner(watchTower);
     watchTowerEditorOwner.owner_id = "1";
+
+    // stairs (components)
+    const stairsEditorOwner = new EditorOwner(stairs);
+    stairsEditorOwner.owner_id = "1";
+
+    // stairs_2 (components)
+    const stairs_2EditorOwner = new EditorOwner(stairs_2);
+    stairs_2EditorOwner.owner_id = "1";
+
+    // wall (components)
+    const wallEditorOwner = new EditorOwner(wall);
+    wallEditorOwner.owner_id = "1";
+
+    // tivaraWorkerMale (components)
+    const tivaraWorkerMaleEditorOwner = new EditorOwner(tivaraWorkerMale);
+    tivaraWorkerMaleEditorOwner.owner_id = "1";
+
+    // wall_1 (components)
+    const wall_1EditorOwner = new EditorOwner(wall_1);
+    wall_1EditorOwner.owner_id = "1";
+
+    // wall_2 (components)
+    const wall_2EditorOwner = new EditorOwner(wall_2);
+    wall_2EditorOwner.owner_id = "1";
+
+    // stairs_1 (components)
+    const stairs_1EditorOwner = new EditorOwner(stairs_1);
+    stairs_1EditorOwner.owner_id = "1";
 
     this.tilemap = tilemap;
 

--- a/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.ts
+++ b/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.ts
@@ -3,11 +3,11 @@
 /* START OF COMPILED CODE */
 
 import GameProbableWaffleScene from "./GameProbableWaffleScene";
-import TivaraWorkerMale from "../prefabs/characters/tivara/TivaraWorkerMale";
-import EditorOwner from "../editor-components/EditorOwner";
 import Tree11 from "../prefabs/outside/foliage/trees/resources/Tree11";
 import WatchTower from "../prefabs/buildings/tivara/wall/WatchTower";
+import EditorOwner from "../editor-components/EditorOwner";
 import Stairs from "../prefabs/buildings/tivara/stairs/Stairs";
+import Wall from "../prefabs/buildings/tivara/wall/Wall";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 
@@ -31,10 +31,6 @@ export default class MapSandbox extends GameProbableWaffleScene {
     // tilemap_level_1
     tilemap.createLayer("TileMap_level_1", ["tiles","tiles_2"], 0, 0);
 
-    // tivaraWorkerMale
-    const tivaraWorkerMale = new TivaraWorkerMale(this, 40, 650);
-    this.add.existing(tivaraWorkerMale);
-
     // tree11
     const tree11 = new Tree11(this, -160, 416);
     this.add.existing(tree11);
@@ -44,20 +40,24 @@ export default class MapSandbox extends GameProbableWaffleScene {
     this.add.existing(watchTower);
 
     // stairs
-    const stairs = new Stairs(this, -160, 624);
+    const stairs = new Stairs(this, -224, 624);
     this.add.existing(stairs);
 
-    // tivaraWorkerMale (components)
-    const tivaraWorkerMaleEditorOwner = new EditorOwner(tivaraWorkerMale);
-    tivaraWorkerMaleEditorOwner.owner_id = "1";
+    // stairs_2
+    const stairs_2 = new Stairs(this, 32, 752);
+    this.add.existing(stairs_2);
+
+    // wall
+    const wall = new Wall(this, 0, 768);
+    this.add.existing(wall);
+
+    // stairs_1
+    const stairs_1 = new Stairs(this, -32, 784);
+    this.add.existing(stairs_1);
 
     // watchTower (components)
     const watchTowerEditorOwner = new EditorOwner(watchTower);
     watchTowerEditorOwner.owner_id = "1";
-
-    // stairs (components)
-    const stairsEditorOwner = new EditorOwner(stairs);
-    stairsEditorOwner.owner_id = "1";
 
     this.tilemap = tilemap;
 

--- a/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.ts
+++ b/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.ts
@@ -5,13 +5,13 @@
 import GameProbableWaffleScene from "./GameProbableWaffleScene";
 import TivaraWorkerMale from "../prefabs/characters/tivara/TivaraWorkerMale";
 import EditorOwner from "../editor-components/EditorOwner";
-import WorkMill from "../prefabs/buildings/tivara/WorkMill";
 import Tree11 from "../prefabs/outside/foliage/trees/resources/Tree11";
-import TivaraSlingshotFemale from "../prefabs/characters/tivara/TivaraSlingshotFemale";
+import WatchTower from "../prefabs/buildings/tivara/wall/WatchTower";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 
 export default class MapSandbox extends GameProbableWaffleScene {
+
   constructor() {
     super("MapSandbox");
 
@@ -21,49 +21,34 @@ export default class MapSandbox extends GameProbableWaffleScene {
   }
 
   editorCreate(): void {
+
     // tilemap
     const tilemap = this.add.tilemap("tiles_river_crossing");
     tilemap.addTilesetImage("tiles", "tiles_1");
     tilemap.addTilesetImage("tiles_2", "tiles_2");
 
     // tilemap_level_1
-    tilemap.createLayer("TileMap_level_1", ["tiles", "tiles_2"], 0, 0);
+    tilemap.createLayer("TileMap_level_1", ["tiles","tiles_2"], 0, 0);
 
     // tivaraWorkerMale
     const tivaraWorkerMale = new TivaraWorkerMale(this, 40, 650);
     this.add.existing(tivaraWorkerMale);
 
-    // workMill
-    const workMill = new WorkMill(this, 448, 736);
-    this.add.existing(workMill);
-
     // tree11
     const tree11 = new Tree11(this, -160, 416);
     this.add.existing(tree11);
 
-    // workMill_1
-    const workMill_1 = new WorkMill(this, -352, 576);
-    this.add.existing(workMill_1);
-
-    // tivaraSlingshotFemale
-    const tivaraSlingshotFemale = new TivaraSlingshotFemale(this, 224, 560);
-    this.add.existing(tivaraSlingshotFemale);
+    // watchTower
+    const watchTower = new WatchTower(this, -192, 592);
+    this.add.existing(watchTower);
 
     // tivaraWorkerMale (components)
     const tivaraWorkerMaleEditorOwner = new EditorOwner(tivaraWorkerMale);
     tivaraWorkerMaleEditorOwner.owner_id = "1";
 
-    // workMill (components)
-    const workMillEditorOwner = new EditorOwner(workMill);
-    workMillEditorOwner.owner_id = "2";
-
-    // workMill_1 (components)
-    const workMill_1EditorOwner = new EditorOwner(workMill_1);
-    workMill_1EditorOwner.owner_id = "1";
-
-    // tivaraSlingshotFemale (components)
-    const tivaraSlingshotFemaleEditorOwner = new EditorOwner(tivaraSlingshotFemale);
-    tivaraSlingshotFemaleEditorOwner.owner_id = "1";
+    // watchTower (components)
+    const watchTowerEditorOwner = new EditorOwner(watchTower);
+    watchTowerEditorOwner.owner_id = "1";
 
     this.tilemap = tilemap;
 

--- a/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.ts
+++ b/apps/client/src/app/probable-waffle/game/scenes/MapSandbox.ts
@@ -7,6 +7,7 @@ import TivaraWorkerMale from "../prefabs/characters/tivara/TivaraWorkerMale";
 import EditorOwner from "../editor-components/EditorOwner";
 import Tree11 from "../prefabs/outside/foliage/trees/resources/Tree11";
 import WatchTower from "../prefabs/buildings/tivara/wall/WatchTower";
+import Stairs from "../prefabs/buildings/tivara/stairs/Stairs";
 /* START-USER-IMPORTS */
 /* END-USER-IMPORTS */
 
@@ -42,6 +43,10 @@ export default class MapSandbox extends GameProbableWaffleScene {
     const watchTower = new WatchTower(this, -192, 592);
     this.add.existing(watchTower);
 
+    // stairs
+    const stairs = new Stairs(this, -160, 624);
+    this.add.existing(stairs);
+
     // tivaraWorkerMale (components)
     const tivaraWorkerMaleEditorOwner = new EditorOwner(tivaraWorkerMale);
     tivaraWorkerMaleEditorOwner.owner_id = "1";
@@ -49,6 +54,10 @@ export default class MapSandbox extends GameProbableWaffleScene {
     // watchTower (components)
     const watchTowerEditorOwner = new EditorOwner(watchTower);
     watchTowerEditorOwner.owner_id = "1";
+
+    // stairs (components)
+    const stairsEditorOwner = new EditorOwner(stairs);
+    stairsEditorOwner.owner_id = "1";
 
     this.tilemap = tilemap;
 

--- a/apps/client/src/app/probable-waffle/game/scenes/services/audio.service.ts
+++ b/apps/client/src/app/probable-waffle/game/scenes/services/audio.service.ts
@@ -1,5 +1,5 @@
 import { VolumeSettings } from "../../core/volumeSettings";
-import { getGameObjectTransform, onSceneInitialized } from "../../data/game-object-helper";
+import { getGameObjectRenderedTransform, onSceneInitialized } from "../../data/game-object-helper";
 import { getSceneExternalComponent } from "../components/scene-component-helpers";
 import { OptionsService } from "../../../gui/options/options.service";
 import { filter, Subscription } from "rxjs";
@@ -197,7 +197,7 @@ export class AudioService {
     gameObject: Phaser.GameObjects.GameObject,
     soundConfig?: Phaser.Types.Sound.SoundConfig
   ): Phaser.Types.Sound.SoundConfig | undefined {
-    const transform = getGameObjectTransform(gameObject);
+    const transform = getGameObjectRenderedTransform(gameObject);
     if (!transform) return undefined;
     if (!gameObject.active || !gameObject.scene) return undefined;
     const camera = gameObject.scene.cameras.main;
@@ -228,7 +228,7 @@ export class AudioService {
     // Compute source position relative to the camera center
     const offsetX = transform.x - camX;
     const offsetY = transform.y - camY;
-    const offsetZ = transform.z ?? 0;
+    const offsetZ = 0; // does not affect in RTS top-down view
 
     // Shrink audible range as you zoom in:
     // World-space viewport size = camera.width / camera.zoom

--- a/apps/client/src/app/probable-waffle/game/scenes/services/navigation.service.ts
+++ b/apps/client/src/app/probable-waffle/game/scenes/services/navigation.service.ts
@@ -1,19 +1,19 @@
 import {
-  js as EasyStar,
-  TOP,
   BOTTOM,
   BOTTOM_LEFT,
-  LEFT,
   BOTTOM_RIGHT,
+  Direction,
+  js as EasyStar,
+  LEFT,
   RIGHT,
+  TOP,
   TOP_LEFT,
-  TOP_RIGHT,
-  Direction
+  TOP_RIGHT
 } from "easystarjs";
 import { Vector2Simple } from "@fuzzy-waddle/api-interfaces";
 import Phaser from "phaser";
 import { getActorComponent } from "../../data/actor-component";
-import { WalkableComponent, WalkablePath } from "../../entity/actor/components/walkable-component";
+import { WalkableComponent } from "../../entity/actor/components/walkable-component";
 import { ColliderComponent } from "../../entity/actor/components/collider-component";
 import { getCenterTileCoordUnderObject, getTileCoordsUnderObject } from "../../library/tile-under-object";
 import { drawDebugPath } from "../../debug/debug-path";
@@ -21,8 +21,9 @@ import { Pathfinder_old } from "../../world/map/pathfinder_old";
 import { drawDebugPoint } from "../../debug/debug-point";
 import { getSceneComponent } from "../components/scene-component-helpers";
 import { TilemapComponent } from "../components/tilemap.component";
-import { onSceneInitialized } from "../../data/game-object-helper";
+import { getSelectableGameObject, onSceneInitialized } from "../../data/game-object-helper";
 import { throttle } from "../../library/throttle";
+import { environment } from "../../../../../environments/environment";
 
 export enum TerrainType {
   Grass = "grass",
@@ -33,14 +34,25 @@ export enum TerrainType {
   Stone = "stone"
 }
 
+// HeightMapCell stores height and walkability info for each tile
+interface HeightMapCell {
+  walkableHeight: number;
+  exitHeight: number;
+  acceptMinimumHeight: number;
+  isWalkable: boolean;
+}
+
 export class NavigationService {
   private readonly terrainTypes = Object.values(TerrainType);
   static UpdateNavigationEvent = "updateNavigation";
   private readonly easyStar: EasyStar;
   private easyStarNavigationGrid: number[][] = [];
   private tilemapGrid: number[][] = [];
+  private heightMapGrid: HeightMapCell[][] = [];
   private readonly DEBUG = false;
   private readonly DEBUG_DEMO = false;
+  private readonly DEBUG_CLICK_INFO = true; // Enable debug click info
+  private directionalConditions: Map<string, Direction[]> = new Map();
 
   constructor(
     private readonly scene: Phaser.Scene,
@@ -56,6 +68,30 @@ export class NavigationService {
     this.extractTilemapGrid();
 
     this.updateNavigation();
+
+    // DEBUG: Bind click listener to print conditional directions and heightMapGrid info
+    if (this.DEBUG_CLICK_INFO && !environment.production) {
+      this.scene.input.on(
+        Phaser.Input.Events.POINTER_UP,
+        (pointer: Phaser.Input.Pointer, gameObjectsUnderCursor: Phaser.GameObjects.GameObject[]) => {
+          const interactiveObjectIds = gameObjectsUnderCursor
+            .map((go) => getSelectableGameObject(go))
+            .filter((go) => !!go) as Phaser.GameObjects.GameObject[];
+          if (interactiveObjectIds.length === 0) return; // No interactive objects clicked
+          const object = interactiveObjectIds[0];
+          const tiles = getTileCoordsUnderObject(this.tilemap, object);
+          console.log("Clicked GameObject:", object);
+          tiles.forEach(({ x, y }) => {
+            const heightInfo = this.heightMapGrid[y]?.[x];
+            const directions = this.directionalConditions.get(`${x}_${y}`);
+            console.log(`Tile (${x},${y}):`, {
+              heightInfo,
+              conditionalDirections: directions
+            });
+          });
+        }
+      );
+    }
 
     if (this.DEBUG_DEMO) {
       try {
@@ -100,7 +136,123 @@ export class NavigationService {
         return tile; // tilemap easyStarNavigationGrid
       })
     );
+    this.extractHeightMapGrid();
     this.setupNavigation();
+  }
+
+  // Populate heightMapGrid with info from tilemap and Walkable objects
+  private extractHeightMapGrid() {
+    // Initialize grid with default values
+    this.heightMapGrid = this.tilemapGrid.map((row) =>
+      row.map((tile) => ({
+        walkableHeight: 0,
+        exitHeight: 0,
+        acceptMinimumHeight: 0,
+        isWalkable: tile === 0
+      }))
+    );
+
+    // Overlay Walkable objects
+    this.scene.children.each((child) => {
+      const walkableComponent = getActorComponent(child, WalkableComponent);
+      if (!walkableComponent) return;
+      const tiles = getTileCoordsUnderObject(this.tilemap, child);
+      const def = walkableComponent.walkableDefinition;
+      tiles.forEach(({ x, y }) => {
+        if (!(this.heightMapGrid[y] && this.heightMapGrid[y][x])) return; // Skip if out of bounds
+        // Check if this walkable is actually accessible (has stairs or adjacent walkable)
+        let accessible = false;
+        // Check neighbors for accessibility
+        const neighborOffsets = [
+          { dx: 0, dy: -1 },
+          { dx: 0, dy: 1 },
+          { dx: -1, dy: 0 },
+          { dx: 1, dy: 0 },
+          { dx: -1, dy: -1 },
+          { dx: 1, dy: -1 },
+          { dx: -1, dy: 1 },
+          { dx: 1, dy: 1 }
+        ];
+        for (const { dx, dy } of neighborOffsets) {
+          const nx = x + dx,
+            ny = y + dy;
+          if (ny >= 0 && ny < this.heightMapGrid.length && nx >= 0 && nx < this.heightMapGrid[ny].length) {
+            const neighbor = this.heightMapGrid[ny][nx];
+            // Accessible if neighbor is walkable and canAccessFrom neighbor to this tile
+            if (
+              neighbor.isWalkable &&
+              this.canAccessFrom(neighbor, {
+                walkableHeight: def.walkableHeight ?? 0,
+                exitHeight: def.exitHeight ?? 0,
+                acceptMinimumHeight: def.acceptMinimumHeight ?? 0,
+                isWalkable: true
+              })
+            ) {
+              accessible = true;
+              break;
+            }
+          }
+        }
+        // If not accessible from any neighbor, do not mark as walkable
+        this.heightMapGrid[y][x] = {
+          walkableHeight: def.walkableHeight ?? 0,
+          exitHeight: def.exitHeight ?? 0,
+          acceptMinimumHeight: def.acceptMinimumHeight ?? 0,
+          isWalkable: accessible
+        };
+      });
+    });
+  }
+
+  private setDirectionalConditions(): void {
+    // For each tile, set directional conditions based on heightMapGrid
+    this.directionalConditions.clear(); // Clear previous conditions
+    for (let y = 0; y < this.heightMapGrid.length; y++) {
+      for (let x = 0; x < this.heightMapGrid[y].length; x++) {
+        const cell = this.heightMapGrid[y][x];
+        if (!cell.isWalkable) continue;
+        const allowedDirections: Direction[] = [];
+
+        // Check all 8 directions
+        const directions: { dir: Direction; dx: number; dy: number }[] = [
+          { dir: TOP, dx: 0, dy: -1 },
+          { dir: BOTTOM, dx: 0, dy: 1 },
+          { dir: LEFT, dx: -1, dy: 0 },
+          { dir: RIGHT, dx: 1, dy: 0 },
+          { dir: TOP_LEFT, dx: -1, dy: -1 },
+          { dir: TOP_RIGHT, dx: 1, dy: -1 },
+          { dir: BOTTOM_LEFT, dx: -1, dy: 1 },
+          { dir: BOTTOM_RIGHT, dx: 1, dy: 1 }
+        ];
+
+        directions.forEach(({ dir, dx, dy }) => {
+          const nx = x + dx;
+          const ny = y + dy;
+          if (ny >= 0 && ny < this.heightMapGrid.length && nx >= 0 && nx < this.heightMapGrid[ny].length) {
+            const neighbor = this.heightMapGrid[ny][nx];
+            if (neighbor.isWalkable && this.canAccessFrom(cell, neighbor)) {
+              allowedDirections.push(dir);
+            }
+          }
+        });
+
+        this.easyStar.setDirectionalCondition(x, y, allowedDirections);
+        if (this.DEBUG_CLICK_INFO && !environment.production) {
+          this.directionalConditions.set(`${x}_${y}`, allowedDirections); // Store for debug
+        }
+      }
+    }
+  }
+
+  // canAccessFrom: allow access if exitHeight of 'from' >= acceptMinimumHeight of 'to'
+  // Or if stairs (walkableHeight < exitHeight) allow access from ground to stairs/wall
+  private canAccessFrom(from: HeightMapCell, to: HeightMapCell): boolean {
+    // Allow access if exitHeight of 'from' >= acceptMinimumHeight of 'to'
+    if (from.exitHeight >= to.acceptMinimumHeight) return true;
+    // Stairs logic: allow access from ground to stairs/wall
+    // noinspection RedundantIfStatementJS
+    if (from.walkableHeight < from.exitHeight && to.walkableHeight >= from.exitHeight) return true;
+    return false;
   }
 
   private async find(fromTileXY: Vector2Simple, toTileXY: Vector2Simple): Promise<Vector2Simple[]> {
@@ -169,38 +321,6 @@ export class NavigationService {
     });
 
     return emptyGrid;
-  }
-
-  private setDirectionalConditions(): void {
-    // for all game objects with WalkableComponent, extract the walkable path definition.
-    this.scene.children.each((child) => {
-      const walkableComponent = getActorComponent(child, WalkableComponent);
-      if (!walkableComponent) return;
-      const walkablePath: WalkablePath = walkableComponent.walkablePathDefinition;
-      const accessibleFromAllSides = walkableComponent.accessibleFromAllSides;
-      if (walkablePath && !accessibleFromAllSides) {
-        const directionalConditions = this.convertWalkablePathToDirectionalConditions(walkablePath);
-        const tileCoords = getTileCoordsUnderObject(this.tilemap, child);
-        for (const tile of tileCoords) {
-          // set directional conditions for the tile in the easyStarNavigationGrid
-          this.easyStar.setDirectionalCondition(tile.x, tile.y, directionalConditions);
-          console.warn("set directional conditions for tile", tile, directionalConditions);
-        }
-      }
-    });
-  }
-
-  private convertWalkablePathToDirectionalConditions(walkablePath: WalkablePath): Direction[] {
-    const conditions: Direction[] = [];
-    if (walkablePath.top) conditions.push(TOP);
-    if (walkablePath.bottom) conditions.push(BOTTOM);
-    if (walkablePath.left) conditions.push(LEFT);
-    if (walkablePath.right) conditions.push(RIGHT);
-    if (walkablePath.topLeft) conditions.push(TOP_LEFT);
-    if (walkablePath.topRight) conditions.push(TOP_RIGHT);
-    if (walkablePath.bottomLeft) conditions.push(BOTTOM_LEFT);
-    if (walkablePath.bottomRight) conditions.push(BOTTOM_RIGHT);
-    return conditions;
   }
 
   /**

--- a/apps/client/src/app/probable-waffle/game/scenes/services/navigation.service.ts
+++ b/apps/client/src/app/probable-waffle/game/scenes/services/navigation.service.ts
@@ -54,7 +54,7 @@ export class NavigationService {
   private easyStarNavigationGrid: number[][] = [];
   private tilemapGrid: number[][] = [];
   private heightMapGrid: HeightMapCell[][] = [];
-  private readonly DEBUG = true;
+  private readonly DEBUG = false;
   private readonly DEBUG_DEMO = false;
   private readonly DEBUG_CLICK_INFO = true; // Enable debug click info
   private directionalConditions: Map<string, Direction[]> = new Map();

--- a/apps/client/src/app/probable-waffle/game/scenes/services/navigation.service.ts
+++ b/apps/client/src/app/probable-waffle/game/scenes/services/navigation.service.ts
@@ -54,7 +54,7 @@ export class NavigationService {
   private easyStarNavigationGrid: number[][] = [];
   private tilemapGrid: number[][] = [];
   private heightMapGrid: HeightMapCell[][] = [];
-  private readonly DEBUG = false;
+  private readonly DEBUG = true;
   private readonly DEBUG_DEMO = false;
   private readonly DEBUG_CLICK_INFO = true; // Enable debug click info
   private directionalConditions: Map<string, Direction[]> = new Map();

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/building-cursor.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/building-cursor.ts
@@ -129,7 +129,7 @@ export class BuildingCursor {
       console.error("Building cursor: RepresentableComponent not found on building game object.");
       return;
     }
-    representableComponent.worldTransform = {
+    representableComponent.logicalWorldTransform = {
       x: worldPosition.x,
       y: worldPosition.y,
       z: 0

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/input/cameraMovementHandler.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/input/cameraMovementHandler.ts
@@ -252,7 +252,7 @@ export class CameraMovementHandler {
     if (!(this.scene instanceof GameProbableWaffleScene)) return;
     const gameScene = this.scene as GameProbableWaffleScene;
     const initialWorldSpawnPosition =
-      gameScene.player.playerController.data.playerDefinition?.initialWorldSpawnPosition;
+      gameScene.player.playerController.data.playerDefinition?.initialWorldLogicalSpawnPosition;
     if (initialWorldSpawnPosition) {
       this.mainCamera.scrollX = initialWorldSpawnPosition.x - this.mainCamera.width / 2;
       this.mainCamera.scrollY = initialWorldSpawnPosition.y - this.mainCamera.height / 2;

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-ai-controller/player-ai-controller.agent.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-ai-controller/player-ai-controller.agent.ts
@@ -17,7 +17,7 @@ import { PawnAiController } from "../player-pawn-ai-controller/pawn-ai-controlle
 import { OrderData } from "../../../../entity/character/ai/OrderData";
 import { OrderType } from "../../../../entity/character/ai/order-type";
 import { BuildingCursor } from "../building-cursor";
-import { getGameObjectTransform } from "../../../../data/game-object-helper";
+import { getGameObjectLogicalTransform, getGameObjectRenderedTransform } from "../../../../data/game-object-helper";
 import { GameplayLibrary } from "../../../../library/gameplay-library";
 import GameObject = Phaser.GameObjects.GameObject;
 
@@ -348,8 +348,9 @@ export class PlayerAiControllerAgent implements IPlayerControllerAgent, Agent {
     // spawn building:
     // get random location - get point next to worker
     const worker = this.blackboard.workers[0];
-    const randomX = getGameObjectTransform(worker)!.x + Math.floor(Math.random() * 10) - 10;
-    const randomY = getGameObjectTransform(worker)!.y + Math.floor(Math.random() * 10) - 10;
+    const transform = getGameObjectLogicalTransform(worker);
+    const randomX = transform!.x + Math.floor(Math.random() * 10) - 10;
+    const randomY = transform!.y + Math.floor(Math.random() * 10) - 10;
     const location = {
       x: randomX,
       y: randomY,

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/node-debugger.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/node-debugger.ts
@@ -2,7 +2,7 @@ import { HealthComponent } from "../../../../entity/combat/components/health-com
 import { getActorComponent } from "../../../../data/actor-component";
 import { ActorTranslateComponent } from "../../../../entity/actor/components/actor-translate-component";
 import { Subscription } from "rxjs";
-import { getGameObjectDepth, getGameObjectTransform, onObjectReady } from "../../../../data/game-object-helper";
+import { getGameObjectDepth, getGameObjectRenderedTransform, onObjectReady } from "../../../../data/game-object-helper";
 import { OwnerComponent } from "../../../../entity/actor/components/owner-component";
 import { HealthUiComponent } from "../../../../entity/combat/components/health-ui-component";
 
@@ -45,13 +45,13 @@ export class NodeDebugger {
   private subscribeActorMove() {
     const actorTranslateComponent = getActorComponent(this.gameObject, ActorTranslateComponent);
     if (!actorTranslateComponent) return;
-    this.actorMovedSubscription = actorTranslateComponent.actorMoved.subscribe(() => {
+    this.actorMovedSubscription = actorTranslateComponent.actorMovedLogicalPosition.subscribe(() => {
       this.updateOwnerUiElementPosition();
     });
   }
 
   private updateOwnerUiElementPosition() {
-    const gameObjectTransform = getGameObjectTransform(this.gameObject);
+    const gameObjectTransform = getGameObjectRenderedTransform(this.gameObject);
     if (!gameObjectTransform || !this.textNode) return;
     const { x, y } = gameObjectTransform;
     this.textNode.setPosition(x, y - 50);

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
@@ -146,7 +146,7 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent, 
       const canMoveToTarget = await this.CanMoveToTarget(range);
       if (!canMoveToTarget) return State.FAILED;
       // console.log("Moving to target!");
-      const success = await movementSystem.moveToActor(target, {
+      const success = await movementSystem.moveToActorByAdjustingPathDynamically(target, {
         radiusTilesAroundDestination: range,
         onUpdateThrottled: () => {
           // if the target is not alive, stop moving
@@ -185,7 +185,7 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent, 
     const movementSystem = getActorSystem(this.gameObject, MovementSystem);
     if (!movementSystem) return State.FAILED;
     try {
-      const success = await movementSystem.moveToLocation(location);
+      const success = await movementSystem.moveToLocationByFollowingStaticPath(location);
       return success ? State.SUCCEEDED : State.FAILED;
     } catch (e) {
       // console.error("Error in MoveToLocation", e);

--- a/apps/client/src/app/probable-waffle/game/world/map/depth.helper.ts
+++ b/apps/client/src/app/probable-waffle/game/world/map/depth.helper.ts
@@ -1,4 +1,4 @@
-import { getGameObjectTransform } from "../../data/game-object-helper";
+import { getGameObjectLogicalTransform, getGameObjectRenderedTransform } from "../../data/game-object-helper";
 import { getActorComponent } from "../../data/actor-component";
 import { FlightComponent } from "../../entity/actor/components/flight-component";
 
@@ -16,7 +16,7 @@ export class DepthHelper {
 
   static setActorDepth(actor: Phaser.GameObjects.GameObject) {
     const actorWithDepth = actor as any as Phaser.GameObjects.Components.Depth;
-    const transform = getGameObjectTransform(actor);
+    const transform = getGameObjectLogicalTransform(actor);
     if (!transform || !actorWithDepth.setDepth) return;
     let newDepth = transform.y;
     if (transform.z) {
@@ -26,7 +26,7 @@ export class DepthHelper {
     // Adjust for flying units: use the bottom of the vertical line (ground location)
     const flightComponent = getActorComponent(actor, FlightComponent);
     if (flightComponent && flightComponent.flightDefinition?.height) {
-      newDepth += flightComponent.flightDefinition.height;
+      newDepth += flightComponent.flightDefinition.height; // todo - maybe this should be added to Z instead?
     }
     actorWithDepth.setDepth(newDepth);
   }

--- a/apps/client/src/app/probable-waffle/gui/instant-game/instant-game.component.ts
+++ b/apps/client/src/app/probable-waffle/gui/instant-game/instant-game.component.ts
@@ -37,7 +37,7 @@ export class InstantGameComponent implements OnInit {
 
     // const allMaps = Object.values(ProbableWaffleLevels);
     // const map = allMaps[Math.floor(Math.random() * allMaps.length)].id;
-    const map = ProbableWaffleMapEnum.Sandbox;
+    const map = ProbableWaffleMapEnum.RiverCrossing;
     await this.gameInstanceClientService.gameModeChanged("map", { map });
     await this.gameInstanceClientService.gameInstanceMetadataChanged("sessionState", {
       sessionState: GameSessionState.MovingPlayersToGame

--- a/apps/client/src/app/probable-waffle/gui/instant-game/instant-game.component.ts
+++ b/apps/client/src/app/probable-waffle/gui/instant-game/instant-game.component.ts
@@ -37,7 +37,7 @@ export class InstantGameComponent implements OnInit {
 
     // const allMaps = Object.values(ProbableWaffleLevels);
     // const map = allMaps[Math.floor(Math.random() * allMaps.length)].id;
-    const map = ProbableWaffleMapEnum.RiverCrossing;
+    const map = ProbableWaffleMapEnum.Sandbox;
     await this.gameInstanceClientService.gameModeChanged("map", { map });
     await this.gameInstanceClientService.gameInstanceMetadataChanged("sessionState", {
       sessionState: GameSessionState.MovingPlayersToGame

--- a/libs/api-interfaces/src/lib/game-instance/probable-waffle/game-state.ts
+++ b/libs/api-interfaces/src/lib/game-instance/probable-waffle/game-state.ts
@@ -4,6 +4,7 @@ import {
   ConstructionSiteComponentData,
   HealthComponentData
 } from "../../communicators/probable-waffle/communicator-game-events";
+import { Vector3Simple } from "../../game/vector";
 
 export interface ProbableWaffleGameCommand {
   command: string;
@@ -36,9 +37,7 @@ export interface ActorDefinition extends Record<string, any> {
   // Constructor name - used to create actor
   name?: string;
 
-  x?: number;
-  y?: number;
-  z?: number;
+  logicalWorldTransform?: Vector3Simple;
 
   // OwnerComponent
   owner?: number;

--- a/libs/api-interfaces/src/lib/game-instance/probable-waffle/player.ts
+++ b/libs/api-interfaces/src/lib/game-instance/probable-waffle/player.ts
@@ -159,7 +159,7 @@ export function getRandomFactionType(): FactionType {
 
 export interface PositionPlayerDefinition {
   // assigned only after entering the game in world space coordinates
-  initialWorldSpawnPosition?: Vector3Simple;
+  initialWorldLogicalSpawnPosition?: Vector3Simple;
   player: PlayerLobbyDefinition;
   team?: number;
   factionType?: FactionType;


### PR DESCRIPTION
## Changes
- added walkable component to allow defining from/to level the actor can be walked over (like from ground via stairs to wall - 64px height)
- allowing walkable path - like over a wall, which only allows certain directions of movement -  and updating directional condition
- adjusted moving to watchtower - now walkable instead of container component
- introduced logicalCoordinates and fixed the Z calculation of flight component so we differentiate between rendered Y and logical Y.
- added git commit instructions
## Not implemented here
- Building and setting of directional conditions is not finalized yet and building of height map in navigation service.
- when moving character to a wall, it's y-axis is jumping up and down