### PR TITLE
#363 feat: add double selection functionality

### DIFF
--- a/apps/client/src/app/probable-waffle/communicators/probable-waffle-communicator.service.ts
+++ b/apps/client/src/app/probable-waffle/communicators/probable-waffle-communicator.service.ts
@@ -45,6 +45,7 @@ export class ProbableWaffleCommunicatorService
       | "restart-game"
       | "selection.deselect"
       | "selection.singleSelect"
+      | "selection.doubleSelect"
       | "selection.multiSelect"
       | "selection.multiSelectPreview"
       | "selection.terrainSelect";

--- a/libs/api-interfaces/src/lib/communicators/probable-waffle/communicator-game-events.ts
+++ b/libs/api-interfaces/src/lib/communicators/probable-waffle/communicator-game-events.ts
@@ -10,6 +10,10 @@ export interface ProbableWaffleSelectionData {
   ctrlKey?: boolean;
 }
 
+export interface ProbableWaffleDoubleSelectionData {
+  objectId: string;
+}
+
 export type HealthComponentData = {
   health: number;
   armour: number;


### PR DESCRIPTION
## Changes
- Introduced a new event for double selection of game objects.
- Implemented double-click detection to trigger the selection.
- Updated relevant handlers to manage double selection logic.

## Motivation
This feature enhances user interaction by allowing players to quickly select multiple objects of the same type through double-clicking, improving gameplay efficiency.