### PR TITLE
#339 Rally - find closest unoccupied location

### DIFF
--- a/apps/client/src/app/probable-waffle/game/entity/building/production/production-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/building/production/production-component.ts
@@ -293,6 +293,7 @@ export class ProductionComponent {
       if (visibilityComponent) visibilityComponent.setVisible(false);
 
       if (this.rallyPoint.isSet()) {
+        // noinspection JSIgnoredPromiseFromCall
         this.rallyPoint.navigateGameObjectToRallyPoint(newGameObject);
       }
     }

--- a/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
@@ -603,6 +603,29 @@ export class MovementSystem {
     // Fallback to original target if no suitable position is found
     return tileVec3;
   }
+
+  /**
+   * Finds the closest unoccupied tile around the target tile and returns it as Vector3Simple.
+   * Unoccupied means no actor sits on the tile (regardless of collider).
+   * Useful for preventing units from stacking on top of each other.
+   */
+  async getClosestUnoccupiedTileVec3(
+    tileVec3: Vector3Simple,
+    maxRadius: number = 10
+  ): Promise<Vector3Simple | undefined> {
+    if (!this.navigationService) return undefined;
+
+    const targetTile = { x: tileVec3.x, y: tileVec3.y };
+    const closestUnoccupiedTile = await this.navigationService.getClosestUnoccupiedTile(targetTile, maxRadius);
+
+    if (!closestUnoccupiedTile) return undefined;
+
+    return {
+      x: closestUnoccupiedTile.x,
+      y: closestUnoccupiedTile.y,
+      z: tileVec3.z
+    };
+  }
 }
 
 export async function getRandomTileInNavigableRadius(

--- a/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
@@ -516,6 +516,9 @@ export class MovementSystem {
   /**
    * Prevents units from clumping up in the same point.
    * It places units in a classic RTS game formation, arranging them in a grid around the target tile.
+   * Todo - this is not the most efficient way to do this:
+   * Todo - instead of finding tileVec3 here, we should rework "command.issued.move"
+   * Todo - to send the target tileVec3 for each actor
    */
   private async getTileVec3ByDynamicFlocking(
     tileVec3: Vector3Simple,

--- a/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
@@ -543,10 +543,11 @@ export class MovementSystem {
       return tileVec3; // Should not happen if logic is correct
     }
 
-    // Use the size of the current unit to determine spacing.
+    // Use a tighter formation spacing for better visual formation
     const tilesUnderGameObject = getTileCoordsUnderObject(this.tileMapComponent.tilemap, this.gameObject);
     const size = tilesUnderGameObject.length > 0 ? Math.ceil(Math.sqrt(tilesUnderGameObject.length)) : 1;
-    const spacingInTiles = size + 1; // Add a buffer tile
+    // Reduce spacing to just the unit size without additional buffer for tighter formations
+    const spacingInTiles = Math.max(1, size);
 
     const gridSize = Math.ceil(Math.sqrt(unitCount));
     const formationPoints: Vector2Simple[] = [];

--- a/apps/client/src/app/probable-waffle/game/prefabs/buildings/misc/RallyPoint.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/buildings/misc/RallyPoint.ts
@@ -70,17 +70,16 @@ export default class RallyPoint extends Phaser.GameObjects.Image {
     this.drawLine();
   }
 
-  navigateGameObjectToRallyPoint(newGameObject: Phaser.GameObjects.GameObject) {
+  async navigateGameObjectToRallyPoint(newGameObject: Phaser.GameObjects.GameObject) {
     const movementSystem = getActorSystem<MovementSystem>(newGameObject, MovementSystem);
     if (!movementSystem) return;
     if (this.tileVec3) {
-      // noinspection JSIgnoredPromiseFromCall
-      movementSystem.moveToLocationByFollowingStaticPath(this.tileVec3);
+      const tileVec3 = (await movementSystem.getClosestUnoccupiedTileVec3(this.tileVec3)) ?? this.tileVec3;
+      await movementSystem.moveToLocationByFollowingStaticPath(tileVec3);
       return;
     }
     if (this.actor) {
-      // noinspection JSIgnoredPromiseFromCall
-      movementSystem.moveToActorByAdjustingPathDynamically(this.actor);
+      await movementSystem.moveToActorByAdjustingPathDynamically(this.actor);
     }
   }
 


### PR DESCRIPTION
## Relates to
https://github.com/JernejHabjan/fuzzy-waddle/pull/422

## Changes
- reduce formation formation spacing
- Added TODO comments in the `getTileVec3ByDynamicFlocking` method.
- Updated `navigateGameObjectToRallyPoint` to use the closest unoccupied tile.
- Added `getClosestUnoccupiedTileVec3` method to find unoccupied tiles.
- Improved movement logic to prevent units from stacking on top of each other.
