### PR TITLE
#410 minmap actions

### DIFF
--- a/apps/client/src/app/probable-waffle/game/data/scene-data.ts
+++ b/apps/client/src/app/probable-waffle/game/data/scene-data.ts
@@ -183,15 +183,19 @@ export function emitEventIssueMoveCommandToSelectedActors(
   });
 }
 
-export function emitEventIssueActorCommandToSelectedActors(scene: Phaser.Scene, objectIds: string[]) {
+export function emitEventIssueActorCommandToSelectedActors(
+  scene: Phaser.Scene,
+  data: {
+    objectIds?: string[];
+    tileVec3?: Vector3Simple;
+  }
+) {
   if (!(scene instanceof ProbableWaffleScene)) throw new Error("Scene is not of type ProbableWaffleScene");
   scene.communicator.playerChanged!.send({
     property: "command.issued.actor",
     data: {
       playerNumber: getPlayer(scene)?.playerNumber,
-      data: {
-        objectIds
-      }
+      data
     },
     gameInstanceId: scene.gameInstanceId,
     emitterUserId: scene.userId

--- a/apps/client/src/app/probable-waffle/game/entity/character/ai/OrderData.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/character/ai/OrderData.ts
@@ -7,7 +7,7 @@ export class OrderData {
     public orderType: OrderType,
     public data: {
       targetGameObject?: GameObject;
-      targetLocation?: Vector3Simple;
+      targetTileLocation?: Vector3Simple;
     } = {}
   ) {}
 }

--- a/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
@@ -95,7 +95,7 @@ export class MovementSystem {
         const newWorldVec3 = await this.getTileVec3ByDynamicFlocking(tileVec3, selectedActorObjectIds);
         const payerPawnAiController = getActorComponent(this.gameObject, PawnAiController);
         if (payerPawnAiController) {
-          const newOrder = new OrderData(OrderType.Move, { targetLocation: newWorldVec3 });
+          const newOrder = new OrderData(OrderType.Move, { targetTileLocation: newWorldVec3 });
           if (this.shiftKey?.isDown) {
             payerPawnAiController.blackboard.addOrder(newOrder);
           } else {

--- a/apps/client/src/app/probable-waffle/game/scenes/GameProbableWaffleScene.ts
+++ b/apps/client/src/app/probable-waffle/game/scenes/GameProbableWaffleScene.ts
@@ -27,6 +27,7 @@ import { getSceneExternalComponent } from "./components/scene-component-helpers"
 import { AchievementService } from "../../services/achievement/achievement.service";
 import { AchievementType } from "../../services/achievement/achievement-type";
 import { environment } from "../../../../environments/environment";
+import { GameObjectActionAssigner } from "../world/managers/controllers/game-object-action-assigner";
 
 export interface ProbableWaffleSceneData {
   baseGameData: ProbableWaffleGameData;
@@ -57,6 +58,7 @@ export default class GameProbableWaffleScene extends ProbableWaffleScene {
     new AnimatedTilemap(this, this.tilemap, this.tilemap.tilesets);
     this.sceneGameData.components.push(new SingleSelectionHandler(this, hud, this.tilemap));
     new GameObjectSelectionHandler(this);
+    new GameObjectActionAssigner(this);
     new SaveGame(this);
     new RestartGame(this, hud);
     new GameModeConditionChecker(this);

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/building-cursor.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/building-cursor.ts
@@ -583,7 +583,7 @@ export class BuildingCursor {
 
     // instruct the builder to start building
     const idComponent = getActorComponent(gameObject, IdComponent)!;
-    emitEventIssueActorCommandToSelectedActors(this.scene, [idComponent.id]);
+    emitEventIssueActorCommandToSelectedActors(this.scene, { objectIds: [idComponent.id] });
   }
 
   static spawnBuildingForPlayer(

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/game-object-action-assigner.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/game-object-action-assigner.ts
@@ -24,6 +24,6 @@ export class GameObjectActionAssigner {
   }
 
   private destroy() {
-    this.scene.events.on(Minimap.assignActorActionToTileCoordinatesEvent, this.assignActionToTileCoordinates, this);
+    this.scene.events.off(Minimap.assignActorActionToTileCoordinatesEvent, this.assignActionToTileCoordinates, this);
   }
 }

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/game-object-action-assigner.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/game-object-action-assigner.ts
@@ -1,0 +1,29 @@
+import Minimap from "../../../prefabs/gui/Minimap";
+import { ProbableWaffleScene } from "../../../core/probable-waffle.scene";
+import { emitEventIssueActorCommandToSelectedActors } from "../../../data/scene-data";
+import { Vector2Simple } from "@fuzzy-waddle/api-interfaces";
+
+export class GameObjectActionAssigner {
+  constructor(private readonly scene: ProbableWaffleScene) {
+    this.bindActionSubscription();
+    this.scene.onShutdown.subscribe(() => this.destroy());
+  }
+
+  private bindActionSubscription() {
+    this.scene.events.on(Minimap.assignActorActionToTileCoordinatesEvent, this.assignActionToTileCoordinates, this);
+  }
+
+  private assignActionToTileCoordinates(tileXY: Vector2Simple) {
+    emitEventIssueActorCommandToSelectedActors(this.scene, {
+      tileVec3: {
+        x: tileXY.x,
+        y: tileXY.y,
+        z: 0
+      }
+    });
+  }
+
+  private destroy() {
+    this.scene.events.on(Minimap.assignActorActionToTileCoordinatesEvent, this.assignActionToTileCoordinates, this);
+  }
+}

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/input/game-object-selection.handler.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/input/game-object-selection.handler.ts
@@ -67,7 +67,7 @@ export class GameObjectSelectionHandler {
                 this.playAudio(objectIds!);
               }
             } else if (isRightClick) {
-              emitEventIssueActorCommandToSelectedActors(this.scene, objectIds!);
+              emitEventIssueActorCommandToSelectedActors(this.scene, { objectIds: objectIds! });
             }
 
             break;

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/input/multi-selection.handler.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/input/multi-selection.handler.ts
@@ -76,6 +76,13 @@ export class MultiSelectionHandler {
     const buildingCursor = getSceneComponent(this.probableWaffleScene, BuildingCursor);
     if (buildingCursor && buildingCursor.placingBuilding) return;
 
+    // Check if pointer is over any interactive HUD elements
+    const hitObjects = this.hudScene.input.hitTestPointer(pointer);
+    if (hitObjects.length > 0) {
+      // Pointer is over a HUD element, don't start multi-selection
+      return;
+    }
+
     this.selection.x = pointer.worldX;
     this.selection.y = pointer.worldY;
     this.selectionRect = null;

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/input/multi-selection.handler.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/input/multi-selection.handler.ts
@@ -80,6 +80,7 @@ export class MultiSelectionHandler {
     const hitObjects = this.hudScene.input.hitTestPointer(pointer);
     if (hitObjects.length > 0) {
       // Pointer is over a HUD element, don't start multi-selection
+      this.pointerWithinGame = false;
       return;
     }
 

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/pawn-ai-controller.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/pawn-ai-controller.ts
@@ -91,7 +91,7 @@ export class PawnAiController {
     const playerOrderTypeName = playerOrderType !== undefined ? OrderType[playerOrderType] : null;
     const targetGameObject = this.blackboard.getCurrentOrder()?.data.targetGameObject;
     const targetGameObjectName = targetGameObject ? targetGameObject.name : null;
-    const targetLocation = this.blackboard.getCurrentOrder()?.data.targetLocation;
+    const targetLocation = this.blackboard.getCurrentOrder()?.data?.targetTileLocation;
     const targetLocationXYZ = targetLocation ? `${targetLocation.x}, ${targetLocation.y}, ${targetLocation.z}` : null;
 
     let text = "";

--- a/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
+++ b/apps/client/src/app/probable-waffle/game/world/managers/controllers/player-pawn-ai-controller/player-pawn-ai-controller.agent.ts
@@ -73,7 +73,7 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent, 
     const currentOrder = this.blackboard.getCurrentOrder();
     if (!currentOrder) return State.FAILED;
     const targetGameObject = currentOrder.data.targetGameObject;
-    const targetLocation = currentOrder.data.targetLocation;
+    const targetLocation = currentOrder.data.targetTileLocation;
     const range = this.getRangeToTarget(type);
     if (range === undefined) return State.FAILED;
     if (targetGameObject) {
@@ -106,7 +106,7 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent, 
     if (!currentOrder) return undefined;
 
     const targetGameObject = currentOrder.data.targetGameObject;
-    const targetLocation = currentOrder.data.targetLocation;
+    const targetLocation = currentOrder.data.targetTileLocation;
     if (targetGameObject) {
       switch (type) {
         case "move":
@@ -167,7 +167,7 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent, 
     const currentOrder = this.blackboard.getCurrentOrder();
     if (!currentOrder) return State.FAILED;
     const target = currentOrder.data.targetGameObject;
-    const location = currentOrder.data.targetLocation;
+    const location = currentOrder.data.targetTileLocation;
     if (target) {
       return await this.MoveToTarget(type);
     } else if (location) {
@@ -180,7 +180,7 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent, 
   async MoveToLocation() {
     const currentOrder = this.blackboard.getCurrentOrder();
     if (!currentOrder) return State.FAILED;
-    const location = currentOrder.data.targetLocation;
+    const location = currentOrder.data.targetTileLocation;
     if (!location) return State.FAILED;
     const movementSystem = getActorSystem(this.gameObject, MovementSystem);
     if (!movementSystem) return State.FAILED;
@@ -433,7 +433,7 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent, 
       return State.FAILED;
     }
     const targetLocation = { x: randomTile.x, y: randomTile.y, z: 0 } satisfies Vector3Simple;
-    this.blackboard.addOrder(new OrderData(OrderType.Move, { targetLocation }));
+    this.blackboard.addOrder(new OrderData(OrderType.Move, { targetTileLocation: targetLocation }));
     return State.SUCCEEDED;
   }
 
@@ -476,7 +476,7 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent, 
   TargetOrLocationExists() {
     const currentOrder = this.blackboard.getCurrentOrder();
     if (!currentOrder) return false;
-    return !!currentOrder.data.targetGameObject || !!currentOrder.data.targetLocation;
+    return !!currentOrder.data.targetGameObject || !!currentOrder.data.targetTileLocation;
   }
 
   /**


### PR DESCRIPTION
- Added a check to determine if the pointer is over any interactive HUD elements.
- If the pointer is over a HUD element, multi-selection will not start.
- Updated `emitEventIssueActorCommandToSelectedActors` to accept an object with optional `objectIds` and `tileVec3`.
- Refactored `OrderData` to use `targetTileLocation` instead of `targetLocation`.
- Introduced `GameObjectActionAssigner` to handle actions assigned to tile coordinates.
- Improved event handling for actor actions in the minimap.

## What this achieves
- allows moving actors to locations via minimap