### PR TITLE
434 State storing pt 3

### DIFF
--- a/.github/workflows/branches.yml
+++ b/.github/workflows/branches.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          lfs: true
+          lfs: false
         #   fetch-depth: 50
 
       - name: Setup pnpm
@@ -55,8 +55,8 @@ jobs:
           NX_BRANCH: ${{ github.event.number }}
           NX_RUN_GROUP: ${{ github.run_id }}
 
-      - name: Build Packages
-        run: pnpm run build-gh-pages
+      - name: Test build
+        run: pnpm run build
         env:
           NX_BRANCH: ${{ github.event.number }}
           NX_RUN_GROUP: ${{ github.run_id }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        lfs: true
+        lfs: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          lfs: true
+          lfs: false
         #   fetch-depth: 50
 
       - name: Setup pnpm
@@ -53,33 +53,33 @@ jobs:
           NX_BRANCH: ${{ github.event.number }}
           NX_RUN_GROUP: ${{ github.run_id }}
 
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          # Upload dist/apps/client
-          path: 'dist/apps/client'
+      # - name: Setup Pages
+      #   uses: actions/configure-pages@v5
+      #
+      # - name: Upload artifact
+      #   uses: actions/upload-pages-artifact@v3
+      #   with:
+      #     # Upload dist/apps/client
+      #     path: 'dist/apps/client'
 
   # Deploy job
-  deploy:
-    # Add a dependency to the build job
-    needs: build
-
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-
-    # Deploy to the github-pages environment
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    # Specify runner + deployment step
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+  #deploy:
+  #  # Add a dependency to the build job
+  #  needs: build
+  #
+  #  # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+  #  permissions:
+  #    pages: write      # to deploy to Pages
+  #    id-token: write   # to verify the deployment originates from an appropriate source
+  #
+  #  # Deploy to the github-pages environment
+  #  environment:
+  #    name: github-pages
+  #    url: ${{ steps.deployment.outputs.page_url }}
+  #
+  #  # Specify runner + deployment step
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    - name: Deploy to GitHub Pages
+  #      id: deployment
+  #      uses: actions/deploy-pages@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,6 @@ jobs:
         with:
           version: 9
 
-      # - name: Lint commits
-      #   uses: wagoid/commitlint-github-action@v4
-
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -37,18 +34,6 @@ jobs:
 
       - name: Install Dependencies
         run: pnpm install
-
-      - name: Run linter
-        run: pnpm run lint
-        env:
-          NX_BRANCH: ${{ github.event.number }}
-          NX_RUN_GROUP: ${{ github.run_id }}
-
-      - name: Run tests
-        run: pnpm run test
-        env:
-          NX_BRANCH: ${{ github.event.number }}
-          NX_RUN_GROUP: ${{ github.run_id }}
 
       - name: Build Packages
         run: pnpm run build-gh-pages

--- a/apps/client/src/app/fly-squasher/game/fly/components/fly-health-component.ts
+++ b/apps/client/src/app/fly-squasher/game/fly/components/fly-health-component.ts
@@ -4,7 +4,7 @@ import { type IFlyBase } from "../component.service";
 import { FlyBase } from "../FlyBase";
 
 export type HealthDefinition = {
-  maxHealth: number;
+  readonly maxHealth: number;
 };
 
 export class FlyHealthComponent implements IFlyBase {

--- a/apps/client/src/app/probable-waffle/game/ai/OrderData.ts
+++ b/apps/client/src/app/probable-waffle/game/ai/OrderData.ts
@@ -37,10 +37,13 @@ export class OrderData {
     const actorIndex = getSceneService(scene, ActorIndexSystem);
     if (record.data?.targetGameObjectId) {
       const targetGameObjectId = record.data.targetGameObjectId as string;
-      const targetGameObject = actorIndex?.getActorById(targetGameObjectId);
-      if (targetGameObject) {
-        data.targetGameObject = targetGameObject;
-      }
+      setTimeout(() => {
+        // resolve asynchronously to avoid issues with actors not yet being created
+        const targetGameObject = actorIndex?.getActorById(targetGameObjectId);
+        if (targetGameObject) {
+          data.targetGameObject = targetGameObject;
+        }
+      }, 0);
     }
     return new OrderData(orderType, data);
   }

--- a/apps/client/src/app/probable-waffle/game/data/actor-manager.ts
+++ b/apps/client/src/app/probable-waffle/game/data/actor-manager.ts
@@ -178,7 +178,7 @@ export class ActorManager {
       production: getActorComponent(actor, ProductionComponent)?.getData(),
       representable: getActorComponent(actor, RepresentableComponent)?.getData(),
       blackboard: getActorComponent(actor, PawnAiController)?.getData()
-    };
+    } satisfies ActorDefinition;
 
     return actorDefinition;
   }

--- a/apps/client/src/app/probable-waffle/game/data/load-game.ts
+++ b/apps/client/src/app/probable-waffle/game/data/load-game.ts
@@ -4,7 +4,7 @@ import { SceneActorCreator } from "../world/services/scene-actor-creator";
 import GameProbableWaffleScene from "../world/scenes/GameProbableWaffleScene";
 import { SelectionGroupsComponent } from "../player/human-controller/selection-groups.component";
 import { CameraMovementHandler } from "../player/human-controller/cameraMovementHandler";
-import { ProbableWafflePlayerType } from "@fuzzy-waddle/api-interfaces";
+import { type ActorId, ProbableWafflePlayerType } from "@fuzzy-waddle/api-interfaces";
 import { AiPlayerHandler } from "../player/ai-controller/ai-player-handler";
 import { emitEventSelection, getSelectableSceneChildren } from "./scene-data";
 import { getActorComponent } from "./actor-component";
@@ -102,7 +102,7 @@ export class LoadGame {
    */
   private syncSelectionToPlayerState(): void {
     const selectableActors = getSelectableSceneChildren(this.scene);
-    const selectedActorIds: string[] = [];
+    const selectedActorIds: ActorId[] = [];
 
     for (const actor of selectableActors) {
       const selectableComponent = getActorComponent(actor, SelectableComponent);

--- a/apps/client/src/app/probable-waffle/game/data/scene-data.ts
+++ b/apps/client/src/app/probable-waffle/game/data/scene-data.ts
@@ -1,4 +1,5 @@
 import {
+  type ActorId,
   type PlayerNumber,
   type PlayerStateHousing,
   type PlayerStateResources,
@@ -208,7 +209,7 @@ export function emitEventIssueMoveCommandToSelectedActors(
   scene: Phaser.Scene,
   tileVec3: Vector3Simple,
   worldVec3: Vector3Simple,
-  selectedActorObjectIds: string[]
+  selectedActorObjectIds: ActorId[]
 ) {
   if (!(scene instanceof ProbableWaffleScene)) throw new Error("Scene is not of type ProbableWaffleScene");
   scene.communicator.playerChanged!.send({

--- a/apps/client/src/app/probable-waffle/game/data/tech-tree/actor-prerequisites.ts
+++ b/apps/client/src/app/probable-waffle/game/data/tech-tree/actor-prerequisites.ts
@@ -5,11 +5,11 @@ export type BuildingPrerequisitesDefinition = {
    * List of building ObjectNames that must exist before this building can be constructed.
    * At least one building from this list must be present for construction to be allowed.
    */
-  requiresAnyOf?: ObjectNames[];
+  readonly requiresAnyOf?: ObjectNames[];
 
   /**
    * List of building ObjectNames that ALL must exist before this building can be constructed.
    * All buildings from this list must be present for construction to be allowed.
    */
-  requiresAllOf?: ObjectNames[];
+  readonly requiresAllOf?: ObjectNames[];
 };

--- a/apps/client/src/app/probable-waffle/game/entity/components/actor-audio/sound-definition.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/actor-audio/sound-definition.ts
@@ -1,4 +1,4 @@
 export type SoundDefinition = {
-  key: string;
-  spriteName: string;
+  readonly key: string;
+  readonly spriteName: string;
 };

--- a/apps/client/src/app/probable-waffle/game/entity/components/animation/animation-definition.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/animation/animation-definition.ts
@@ -1,5 +1,5 @@
 export type AnimationDefinition = {
-  key: string;
-  frameRate?: number;
-  repeat?: number;
+  readonly key: string;
+  readonly frameRate?: number;
+  readonly repeat?: number;
 };

--- a/apps/client/src/app/probable-waffle/game/entity/components/building/container-definition.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/building/container-definition.ts
@@ -1,3 +1,3 @@
 export type ContainerDefinition = {
-  capacity: number;
+  readonly capacity: number;
 };

--- a/apps/client/src/app/probable-waffle/game/entity/components/building/housing-cost-definition.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/building/housing-cost-definition.ts
@@ -1,3 +1,3 @@
 export type HousingCostDefinition = {
-  housingNeeded: number;
+  readonly housingNeeded: number;
 };

--- a/apps/client/src/app/probable-waffle/game/entity/components/building/housing-definition.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/building/housing-definition.ts
@@ -1,3 +1,3 @@
 export type HousingDefinition = {
-  housingCapacity: number;
+  readonly housingCapacity: number;
 };

--- a/apps/client/src/app/probable-waffle/game/entity/components/combat/components/attack-definition.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/combat/components/attack-definition.ts
@@ -1,5 +1,5 @@
 import type { AttackData } from "../attack-data";
 
 export type AttackDefinition = {
-  attacks: AttackData[];
+  readonly attacks: AttackData[];
 };

--- a/apps/client/src/app/probable-waffle/game/entity/components/combat/components/healing-definition.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/combat/components/healing-definition.ts
@@ -1,5 +1,5 @@
 export type HealingDefinition = {
-  healPerCooldown: number;
-  cooldown: number;
-  range: number;
+  readonly healPerCooldown: number;
+  readonly cooldown: number;
+  readonly range: number;
 };

--- a/apps/client/src/app/probable-waffle/game/entity/components/combat/components/health-definition.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/combat/components/health-definition.ts
@@ -1,9 +1,9 @@
 import { ActorPhysicalType } from "./actor-physical-type";
 
 export type HealthDefinition = {
-  maxHealth: number;
-  maxArmour?: number;
-  regenerateHealthRate?: number;
-  healthDisplayBehavior?: "always" | "onDamage";
-  physicalState: ActorPhysicalType;
+  readonly maxHealth: number;
+  readonly maxArmour?: number;
+  readonly regenerateHealthRate?: number;
+  readonly healthDisplayBehavior?: "always" | "onDamage";
+  readonly physicalState: ActorPhysicalType;
 };

--- a/apps/client/src/app/probable-waffle/game/entity/components/construction/builder-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/construction/builder-component.ts
@@ -297,10 +297,6 @@ export class BuilderComponent {
 
   setData(data: Partial<BuilderComponentData>) {
     if (data.remainingCooldown !== undefined) this.remainingCooldown = data.remainingCooldown;
-    if (data.enterConstructionSite !== undefined)
-      this.builderComponentDefinition.enterConstructionSite = data.enterConstructionSite;
-    if (data.constructionSiteOffset !== undefined)
-      this.builderComponentDefinition.constructionSiteOffset = data.constructionSiteOffset;
     if (data.assignedConstructionSiteId) {
       const actorIndex = getSceneService(this.gameObject.scene, ActorIndexSystem);
       const actorById = actorIndex?.getActorById(data.assignedConstructionSiteId);
@@ -313,8 +309,6 @@ export class BuilderComponent {
   getData(): BuilderComponentData {
     return {
       remainingCooldown: this.remainingCooldown,
-      enterConstructionSite: this.builderComponentDefinition.enterConstructionSite,
-      constructionSiteOffset: this.builderComponentDefinition.constructionSiteOffset,
       assignedConstructionSiteId: this.assignedConstructionSite
         ? getActorComponent(this.assignedConstructionSite, IdComponent)?.id
         : undefined

--- a/apps/client/src/app/probable-waffle/game/entity/components/construction/builder-definition.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/construction/builder-definition.ts
@@ -2,9 +2,9 @@ import { ConstructableDefinition } from "./constructable-category";
 
 export type BuilderDefinition = {
   // types of building the gameObject can produce
-  constructableBuildings: ConstructableDefinition;
+  readonly constructableBuildings: ConstructableDefinition;
   // Whether the builder enters the building site while working on it, or not.
-  enterConstructionSite: boolean;
+  readonly enterConstructionSite: boolean;
   // from how far a builder builds building site
-  constructionSiteOffset: number;
+  readonly constructionSiteOffset: number;
 };

--- a/apps/client/src/app/probable-waffle/game/entity/components/construction/construction-site-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/construction/construction-site-component.ts
@@ -25,7 +25,9 @@ import {
 import { PawnAiController } from "../../../prefabs/ai-agents/pawn-ai-controller";
 import type { ConstructionSiteDefinition } from "./construction-site-definition";
 import type { ProductionCostDefinition } from "../production/production-cost-definition";
+import { IdComponent } from "../id-component";
 import GameObject = Phaser.GameObjects.GameObject;
+import { ActorIndexSystem } from "../../../world/services/ActorIndexSystem";
 
 export class ConstructionSiteComponent {
   public progressPercentage = 0;
@@ -33,9 +35,7 @@ export class ConstructionSiteComponent {
     this.progressPercentage
   );
   private remainingConstructionTime = 0;
-  private constructionSiteData: ConstructionSiteComponentData = {
-    state: ConstructionStateEnum.NotStarted
-  } satisfies ConstructionSiteComponentData;
+  private state: ConstructionStateEnum = ConstructionStateEnum.NotStarted;
   public constructionStateChanged: Subject<ConstructionStateEnum> = new Subject<ConstructionStateEnum>();
   private assignedBuilders: GameObject[] = [];
   private assignedRepairers: GameObject[] = [];
@@ -55,10 +55,10 @@ export class ConstructionSiteComponent {
   }
 
   private init() {
-    if (this.constructionSiteData.state === ConstructionStateEnum.NotStarted) {
+    if (this.state === ConstructionStateEnum.NotStarted) {
       this.setInitialHealth();
     }
-    if (this.constructionSiteData.state === ConstructionStateEnum.Finished) {
+    if (this.state === ConstructionStateEnum.Finished) {
       this.progressPercentage = 100;
       this.constructionProgressPercentageChanged.next(this.progressPercentage);
     }
@@ -74,7 +74,7 @@ export class ConstructionSiteComponent {
   update(_: number, delta: number): void {
     const deltaWithTimeScale = delta * this.gameObject.scene.time.timeScale;
 
-    if (this.constructionSiteData.state == ConstructionStateEnum.Finished) {
+    if (this.state == ConstructionStateEnum.Finished) {
       this.tryRepair(deltaWithTimeScale);
       return;
     }
@@ -83,19 +83,16 @@ export class ConstructionSiteComponent {
   }
 
   private tryBuild(deltaWithTimeScale: number) {
-    if (
-      this.constructionSiteData.state === ConstructionStateEnum.NotStarted &&
-      this.constructionSiteDefinition.startImmediately
-    ) {
+    if (this.state === ConstructionStateEnum.NotStarted && this.constructionSiteDefinition.startImmediately) {
       this.startConstruction();
       this.setInitialHealth();
     }
 
-    if (this.constructionSiteData.state === ConstructionStateEnum.NotStarted && this.assignedBuilders.length > 0) {
+    if (this.state === ConstructionStateEnum.NotStarted && this.assignedBuilders.length > 0) {
       this.startConstruction();
     }
 
-    if (this.constructionSiteData.state !== ConstructionStateEnum.Constructing) return;
+    if (this.state !== ConstructionStateEnum.Constructing) return;
 
     if (this.healthComponent?.killed) return;
 
@@ -166,7 +163,7 @@ export class ConstructionSiteComponent {
   }
 
   startConstruction() {
-    if (this.constructionSiteData.state !== ConstructionStateEnum.NotStarted) {
+    if (this.state !== ConstructionStateEnum.NotStarted) {
       throw new Error("ConstructionSiteComponent can only be started once");
     }
     const productionDefinition = this.productionDefinition;
@@ -188,8 +185,8 @@ export class ConstructionSiteComponent {
 
     // start building
     this.remainingConstructionTime = productionDefinition.productionTime;
-    this.constructionSiteData.state = ConstructionStateEnum.Constructing;
-    this.constructionStateChanged.next(this.constructionSiteData.state);
+    this.state = ConstructionStateEnum.Constructing;
+    this.constructionStateChanged.next(this.state);
   }
 
   private setInitialHealth() {
@@ -234,7 +231,7 @@ export class ConstructionSiteComponent {
   }
 
   get isFinished() {
-    return this.constructionSiteData.state === ConstructionStateEnum.Finished;
+    return this.state === ConstructionStateEnum.Finished;
   }
 
   canAssignBuilder() {
@@ -302,8 +299,8 @@ export class ConstructionSiteComponent {
   }
 
   private finishConstruction() {
-    this.constructionSiteData.state = ConstructionStateEnum.Finished;
-    this.constructionStateChanged.next(this.constructionSiteData.state);
+    this.state = ConstructionStateEnum.Finished;
+    this.constructionStateChanged.next(this.state);
 
     const visibilityComponent = getGameObjectVisibility(this.gameObject);
     if (visibilityComponent && visibilityComponent.visible) {
@@ -329,12 +326,38 @@ export class ConstructionSiteComponent {
   }
 
   getData(): ConstructionSiteComponentData {
-    return this.constructionSiteData;
+    return {
+      state: this.state,
+      remainingConstructionTime: this.remainingConstructionTime,
+      progressPercentage: this.progressPercentage,
+      assignedBuilders: this.assignedBuilders.map((builder) => getActorComponent(builder, IdComponent)!.id),
+      assignedRepairers: this.assignedRepairers.map((repairer) => getActorComponent(repairer, IdComponent)!.id),
+      playingBuildSound: this.playingBuildSound
+    } satisfies ConstructionSiteComponentData;
   }
 
   setData(data: Partial<ConstructionSiteComponentData>) {
-    this.constructionSiteData = { ...this.constructionSiteData, ...data };
-    this.constructionStateChanged.next(this.constructionSiteData.state);
+    if (data.state !== undefined) this.state = data.state;
+    if (data.remainingConstructionTime !== undefined) this.remainingConstructionTime = data.remainingConstructionTime;
+    if (data.progressPercentage !== undefined) this.progressPercentage = data.progressPercentage;
+    if (data.playingBuildSound !== undefined) this.playingBuildSound = data.playingBuildSound;
+    // assigned builders and repairers are set after all objects are loaded.
+    setTimeout(() => {
+      const actorIndex = getSceneService(this.gameObject.scene, ActorIndexSystem);
+      if (actorIndex && data.assignedBuilders) {
+        this.assignedBuilders = data.assignedBuilders
+          .map((id) => actorIndex.getActorById(id))
+          .filter((obj): obj is GameObject => obj !== undefined);
+      }
+      if (actorIndex && data.assignedRepairers) {
+        this.assignedRepairers = data.assignedRepairers
+          .map((id) => actorIndex.getActorById(id))
+          .filter((obj): obj is GameObject => obj !== undefined);
+      }
+    }, 50);
+
+    this.constructionProgressPercentageChanged.next(this.progressPercentage);
+    this.constructionStateChanged.next(this.state);
   }
 
   private onDestroy() {

--- a/apps/client/src/app/probable-waffle/game/entity/components/construction/construction-site-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/construction/construction-site-component.ts
@@ -347,12 +347,12 @@ export class ConstructionSiteComponent {
       if (actorIndex && data.assignedBuilders) {
         this.assignedBuilders = data.assignedBuilders
           .map((id) => actorIndex.getActorById(id))
-          .filter((obj): obj is GameObject => obj !== undefined);
+          .filter((obj): obj is GameObject => obj !== null);
       }
       if (actorIndex && data.assignedRepairers) {
         this.assignedRepairers = data.assignedRepairers
           .map((id) => actorIndex.getActorById(id))
-          .filter((obj): obj is GameObject => obj !== undefined);
+          .filter((obj): obj is GameObject => obj !== null);
       }
     }, 50);
 

--- a/apps/client/src/app/probable-waffle/game/entity/components/construction/construction-site-definition.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/construction/construction-site-definition.ts
@@ -1,20 +1,20 @@
 export type ConstructionSiteDefinition = {
   // Whether the building site consumes builders when building is finished
-  consumesBuilders: boolean;
-  maxAssignedBuilders: number;
-  maxAssignedRepairers: number;
+  readonly consumesBuilders: boolean;
+  readonly maxAssignedBuilders: number;
+  readonly maxAssignedRepairers: number;
   // Factor to multiply all passed building time with, independent of any currently assigned builders
-  progressMadeAutomatically: number;
+  readonly progressMadeAutomatically: number;
   // Factor to multiply all passed building time with, dependent on the number of builders assigned
-  progressMadePerBuilder: number;
-  repairFactor: number;
-  initialHealthPercentage: number;
-  refundFactor: number;
+  readonly progressMadePerBuilder: number;
+  readonly repairFactor: number;
+  readonly initialHealthPercentage: number;
+  readonly refundFactor: number;
   // Whether to start building immediately after spawn, or not
-  startImmediately: boolean;
-  finishedSound?: {
+  readonly startImmediately: boolean;
+  readonly finishedSound?: {
     key: string;
   };
   // Whether multiple buildings can be placed one after another by dragging the mouse - Wall building for example
-  canBeDragPlaced: boolean;
+  readonly canBeDragPlaced: boolean;
 };

--- a/apps/client/src/app/probable-waffle/game/entity/components/convertible-definition.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/convertible-definition.ts
@@ -1,4 +1,4 @@
 export type ConvertibleDefinition = {
-  detectionRange: number;
-  checkInterval: number;
+  readonly detectionRange: number;
+  readonly checkInterval: number;
 };

--- a/apps/client/src/app/probable-waffle/game/entity/components/id-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/id-component.ts
@@ -1,9 +1,9 @@
-import { Guid, type IdComponentData } from "@fuzzy-waddle/api-interfaces";
+import { type ActorId, Guid, type IdComponentData } from "@fuzzy-waddle/api-interfaces";
 
 export class IdComponent {
-  id = new Guid().value;
+  id: ActorId = new Guid().value;
 
-  setId(id: string) {
+  setId(id: ActorId) {
     this.id = id;
   }
 

--- a/apps/client/src/app/probable-waffle/game/entity/components/owner-definition.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/owner-definition.ts
@@ -1,3 +1,3 @@
 export type OwnerDefinition = {
-  color: { originalColor: number; epsilon: number }[];
+  readonly color: { originalColor: number; epsilon: number }[];
 };

--- a/apps/client/src/app/probable-waffle/game/entity/components/production/production-cost-definition.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/production/production-cost-definition.ts
@@ -2,8 +2,8 @@ import { PaymentType } from "./payment-type";
 import { ResourceType } from "@fuzzy-waddle/api-interfaces";
 
 export type ProductionCostDefinition = {
-  costType: PaymentType;
-  productionTime: number;
-  resources: Partial<Record<ResourceType, number>>;
-  refundFactor: number;
+  readonly costType: PaymentType;
+  readonly productionTime: number;
+  readonly resources: Partial<Record<ResourceType, number>>;
+  readonly refundFactor: number;
 };

--- a/apps/client/src/app/probable-waffle/game/entity/components/production/production-definition.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/production/production-definition.ts
@@ -1,8 +1,8 @@
 import { ObjectNames } from "@fuzzy-waddle/api-interfaces";
 
 export type ProductionDefinition = {
-  availableProduceActors: ObjectNames[];
+  readonly availableProduceActors: ObjectNames[];
   // How many products can be produced simultaneously - for example 2 marines (SC2)
-  queueCount: number;
-  capacityPerQueue: number;
+  readonly queueCount: number;
+  readonly capacityPerQueue: number;
 };

--- a/apps/client/src/app/probable-waffle/game/entity/components/requirements-definition.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/requirements-definition.ts
@@ -1,5 +1,5 @@
 import { ObjectNames } from "@fuzzy-waddle/api-interfaces";
 
 export type RequirementsDefinition = {
-  actors: ObjectNames[];
+  readonly actors: ObjectNames[];
 };

--- a/apps/client/src/app/probable-waffle/game/entity/components/resource/gatherer-definition.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/resource/gatherer-definition.ts
@@ -1,6 +1,6 @@
 export type GathererDefinition = {
   // types of gameObjects the gatherer can gather resourcesFrom
-  resourceSourceGameObjectClasses: string[];
+  readonly resourceSourceGameObjectClasses: string[];
   // radius in which gameObject will automatically gather resourcesFrom
-  resourceSweepRadius: number;
+  readonly resourceSweepRadius: number;
 };

--- a/apps/client/src/app/probable-waffle/game/entity/components/resource/resource-drain-definition.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/resource/resource-drain-definition.ts
@@ -1,6 +1,6 @@
 import { ResourceType } from "@fuzzy-waddle/api-interfaces";
 
 export type ResourceDrainDefinition = {
-  resourceTypes: ResourceType[];
-  cooldown: number;
+  readonly resourceTypes: ResourceType[];
+  readonly cooldown: number;
 };

--- a/apps/client/src/app/probable-waffle/game/entity/components/resource/resource-source-definition.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/resource/resource-source-definition.ts
@@ -1,9 +1,9 @@
 import { ResourceType } from "@fuzzy-waddle/api-interfaces";
 
 export type ResourceSourceDefinition = {
-  resourceType: ResourceType;
-  maximumResources: number;
-  gatheringFactor: number;
-  maxGatherers?: number;
-  cooldown: number;
+  readonly resourceType: ResourceType;
+  readonly maximumResources: number;
+  readonly gatheringFactor: number;
+  readonly maxGatherers?: number;
+  readonly cooldown: number;
 };

--- a/apps/client/src/app/probable-waffle/game/entity/components/selectable-definition.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/selectable-definition.ts
@@ -1,4 +1,4 @@
 export type SelectableDefinition = {
-  offsetY?: number;
-  sizeFactorReduction?: number;
+  readonly offsetY?: number;
+  readonly sizeFactorReduction?: number;
 };

--- a/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
@@ -456,6 +456,8 @@ export class MovementSystem {
       : undefined;
 
     return new Promise<void>((resolve, reject) => {
+      const isKilled = getActorComponent(this.gameObject, HealthComponent)?.killed ?? false;
+      if (isKilled) return reject("Actor is killed");
       this.onMovementStart(newLogicalTransform, config);
       const representableComponent = getActorComponent(this.gameObject, RepresentableComponent);
       if (!representableComponent) return reject("No representable component");

--- a/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
@@ -1,4 +1,4 @@
-import type { Vector2Simple, Vector3Simple } from "@fuzzy-waddle/api-interfaces";
+import type { ActorId, Vector2Simple, Vector3Simple } from "@fuzzy-waddle/api-interfaces";
 import { getSceneComponent, getSceneService } from "../../world/services/scene-component-helpers";
 import { NavigationService, TerrainType } from "../../world/services/navigation.service";
 import { throttle } from "../../library/throttle";
@@ -617,7 +617,7 @@ export class MovementSystem {
    */
   private async getTileVec3ByDynamicFlocking(
     tileVec3: Vector3Simple,
-    selectedActorObjectIds: string[]
+    selectedActorObjectIds: ActorId[]
   ): Promise<Vector3Simple> {
     const unitCount = selectedActorObjectIds.length;
     if (unitCount < 2) {

--- a/apps/client/src/app/probable-waffle/game/player/faction-definitions.ts
+++ b/apps/client/src/app/probable-waffle/game/player/faction-definitions.ts
@@ -3,12 +3,20 @@ import { FactionType, ObjectNames } from "@fuzzy-waddle/api-interfaces";
 
 export class FactionDefinitions {
   static tivara: FactionInfo = new FactionInfo(FactionType.Tivara, "Tivara", [
-    ObjectNames.Sandhold,
-    ObjectNames.TivaraMacemanMale
+    {
+      actorName: ObjectNames.Sandhold
+    },
+    {
+      actorName: ObjectNames.TivaraMacemanMale
+    }
   ]);
   static skaduwee: FactionInfo = new FactionInfo(FactionType.Skaduwee, "Skaduwee", [
-    ObjectNames.FrostForge,
-    ObjectNames.SkaduweeMagicianFemale
+    {
+      actorName: ObjectNames.FrostForge
+    },
+    {
+      actorName: ObjectNames.SkaduweeMagicianFemale
+    }
   ]);
 
   static factions: { type: FactionType; value: FactionInfo }[] = [

--- a/apps/client/src/app/probable-waffle/game/player/faction-info.ts
+++ b/apps/client/src/app/probable-waffle/game/player/faction-info.ts
@@ -15,8 +15,6 @@ export class FactionInfo {
     public name: string,
     /**
      * Actors to spawn for each player in the game.
-     * Can be ObjectNames[] for backwards compatibility (all spawn as Finished),
-     * or InitialActorConfig[] to specify construction states.
      */
     public readonly initialActors: InitialActorConfig[] = []
   ) {}

--- a/apps/client/src/app/probable-waffle/game/player/faction-info.ts
+++ b/apps/client/src/app/probable-waffle/game/player/faction-info.ts
@@ -1,12 +1,23 @@
-import { FactionType, ObjectNames } from "@fuzzy-waddle/api-interfaces";
+import { ConstructionStateEnum, FactionType, ObjectNames } from "@fuzzy-waddle/api-interfaces";
+
+export interface InitialActorConfig {
+  actorName: ObjectNames;
+  /**
+   * Optional construction state. Defaults to Finished.
+   * Use NotStarted or Constructing to spawn buildings that need to be constructed.
+   */
+  constructionState?: ConstructionStateEnum;
+}
 
 export class FactionInfo {
   constructor(
     public factionType: FactionType,
     public name: string,
     /**
-     * Actors to spawn for each player in the game
+     * Actors to spawn for each player in the game.
+     * Can be ObjectNames[] for backwards compatibility (all spawn as Finished),
+     * or InitialActorConfig[] to specify construction states.
      */
-    public readonly initialActors: ObjectNames[] = []
+    public readonly initialActors: InitialActorConfig[] = []
   ) {}
 }

--- a/apps/client/src/app/probable-waffle/game/player/human-controller/game-object-selection.handler.ts
+++ b/apps/client/src/app/probable-waffle/game/player/human-controller/game-object-selection.handler.ts
@@ -15,6 +15,7 @@ import { AttackComponent } from "../../entity/components/combat/components/attac
 import { ProductionCostComponent } from "../../entity/components/production/production-cost-component";
 import { HealthComponent } from "../../entity/components/combat/components/health-component";
 import {
+  type ActorId,
   ObjectNames,
   type ProbableWaffleDoubleSelectionData,
   type ProbableWaffleSelectionData
@@ -237,7 +238,7 @@ export class GameObjectSelectionHandler {
     }
   }
 
-  private playAudio(actorIds: string[]) {
+  private playAudio(actorIds: ActorId[]) {
     if (!actorIds.length) return;
     const firstActorId = actorIds[0]!;
     const firstActor = this.getActorsByIds([firstActorId])[0];
@@ -261,7 +262,7 @@ export class GameObjectSelectionHandler {
    * Gets game objects in current users viewport by the same actor name.
    * Used when double-clicking on an actor to select same actors on screen by type
    */
-  private getSameTypeActorsInViewportById(objectId: string): GameObject[] {
+  private getSameTypeActorsInViewportById(objectId: ActorId): GameObject[] {
     const selectableChildren = this.getSelectableChildren();
 
     // Find the original actor to get its type/name

--- a/apps/client/src/app/probable-waffle/game/player/human-controller/single-selection.handler.ts
+++ b/apps/client/src/app/probable-waffle/game/player/human-controller/single-selection.handler.ts
@@ -4,6 +4,7 @@ import { getActorComponent } from "../../data/actor-component";
 import { IdComponent } from "../../entity/components/id-component";
 import { MULTI_SELECTING } from "./multi-selection.handler";
 import type {
+  ActorId,
   ProbableWaffleDoubleSelectionData,
   ProbableWaffleSelectionData,
   Vector3Simple
@@ -148,7 +149,7 @@ export class SingleSelectionHandler {
 
   public sendSelection(
     button: "left" | "right",
-    objectIds: string[],
+    objectIds: ActorId[],
     shiftKey: boolean = false,
     ctrlKey: boolean = false
   ) {
@@ -163,7 +164,7 @@ export class SingleSelectionHandler {
     });
   }
 
-  public sendDoubleClick(objectId: string) {
+  public sendDoubleClick(objectId: ActorId) {
     this.scene.communicator.allScenes!.emit({
       name: "selection.doubleSelect",
       data: {

--- a/apps/client/src/app/probable-waffle/game/prefabs/ai-agents/player-pawn-ai-controller.agent.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/ai-agents/player-pawn-ai-controller.agent.ts
@@ -258,7 +258,7 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent {
   }
 
   Stop = (fromNode: string) => {
-    // console.log(`[Build] Stop called from: ${fromNode}`);
+    // console.log(`Stop called from: ${fromNode}`);
 
     const currentOrder = this.blackboard.getCurrentOrder();
     if (currentOrder) {

--- a/apps/client/src/app/probable-waffle/game/prefabs/ai-agents/player-pawn-ai-controller.agent.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/ai-agents/player-pawn-ai-controller.agent.ts
@@ -465,13 +465,6 @@ export class PlayerPawnAiControllerAgent implements IPlayerPawnControllerAgent {
       return State.FAILED;
     }
     // Check if in range before trying to construct
-    const range = builderComponent.getConstructionRange();
-    const distance = DistanceHelper.getTileDistanceBetweenGameObjects(this.gameObject, target);
-    // console.log("[Build] ConstructBuilding: range=", range, "distance=", distance);
-    if (distance === null || distance > range) {
-      // console.log("[Build] ConstructBuilding: Not in range");
-      return State.FAILED;
-    }
     const constructionSiteComponent = getActorComponent(target, ConstructionSiteComponent);
     if (!constructionSiteComponent) {
       // console.log("[Build] ConstructBuilding: No construction site component");

--- a/apps/client/src/app/probable-waffle/game/world/scenes/game-maps/MapEmberEnclave.ts
+++ b/apps/client/src/app/probable-waffle/game/world/scenes/game-maps/MapEmberEnclave.ts
@@ -1,4 +1,6 @@
 // You can write more code here
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
 
 /* START OF COMPILED CODE */
 
@@ -217,7 +219,7 @@ export default class MapEmberEnclave extends GameProbableWaffleScene {
     this.events.emit("scene-awake");
   }
 
-  public override tilemap!: Phaser.Tilemaps.Tilemap;
+  public tilemap!: Phaser.Tilemaps.Tilemap;
 
   /* START-USER-CODE */
 

--- a/apps/client/src/app/probable-waffle/game/world/scenes/game-maps/MapSandbox.ts
+++ b/apps/client/src/app/probable-waffle/game/world/scenes/game-maps/MapSandbox.ts
@@ -1,4 +1,6 @@
 // You can write more code here
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
 
 /* START OF COMPILED CODE */
 
@@ -103,7 +105,7 @@ export default class MapSandbox extends GameProbableWaffleScene {
     this.events.emit("scene-awake");
   }
 
-  public override tilemap!: Phaser.Tilemaps.Tilemap;
+  public tilemap!: Phaser.Tilemaps.Tilemap;
 
   /* START-USER-CODE */
   override create() {

--- a/apps/client/src/app/probable-waffle/game/world/services/ActorIndexSystem.ts
+++ b/apps/client/src/app/probable-waffle/game/world/services/ActorIndexSystem.ts
@@ -4,7 +4,7 @@ import { IdComponent } from "../../entity/components/id-component";
 import { OwnerComponent } from "../../entity/components/owner-component";
 import { ResourceSourceComponent } from "../../entity/components/resource/resource-source-component";
 import { ResourceDrainComponent } from "../../entity/components/resource/resource-drain-component";
-import { ObjectNames, type PlayerNumber, ResourceType } from "@fuzzy-waddle/api-interfaces";
+import { type ActorId, ObjectNames, type PlayerNumber, ResourceType } from "@fuzzy-waddle/api-interfaces";
 import { HealthComponent } from "../../entity/components/combat/components/health-component";
 import { getTileCoordsUnderObject } from "../../library/tile-under-object";
 import { getSceneComponent, getSceneService } from "./scene-component-helpers";
@@ -168,7 +168,7 @@ export class ActorIndexSystem {
     return Array.from(this.idActors);
   }
 
-  getActorById(id: string): GameObject | null {
+  getActorById(id: ActorId): GameObject | null {
     for (const obj of this.idActors) {
       const idComp = getActorComponent(obj, IdComponent);
       if (idComp?.id === id) {
@@ -178,7 +178,7 @@ export class ActorIndexSystem {
     return null;
   }
 
-  getActorsByIds(ids: string[]): GameObject[] {
+  getActorsByIds(ids: ActorId[]): GameObject[] {
     const result: GameObject[] = [];
     const idSet = new Set(ids);
     for (const obj of this.idActors) {

--- a/apps/client/src/app/probable-waffle/game/world/services/scene-actor-creator.ts
+++ b/apps/client/src/app/probable-waffle/game/world/services/scene-actor-creator.ts
@@ -22,6 +22,7 @@ import { IdComponent } from "../../entity/components/id-component";
 import { getSceneService } from "./scene-component-helpers";
 import { ActorIndexSystem } from "./ActorIndexSystem";
 import { LoadGame } from "../../data/load-game";
+import type { InitialActorConfig } from "../../player/faction-info";
 
 export class SceneActorCreator {
   private readonly loadGame: LoadGame;
@@ -100,10 +101,24 @@ export class SceneActorCreator {
 
   public createActorFromDefinition(actorDefinition: ActorDefinition): Phaser.GameObjects.GameObject | undefined {
     if (!actorDefinition.name) return undefined;
-    const actor = ActorManager.createActorFully(this.scene, actorDefinition.name as ObjectNames, actorDefinition);
+
+    const shouldConstructFully = this.shouldConstructActorFully(actorDefinition);
+    let actor;
+    if (shouldConstructFully) {
+      actor = ActorManager.createActorFully(this.scene, actorDefinition.name as ObjectNames, actorDefinition);
+    } else {
+      // not fully built construction site
+      actor = ActorManager.createActorConstructing(this.scene, actorDefinition.name as ObjectNames, actorDefinition);
+    }
+
     const gameObject = this.scene.add.existing(actor);
     this.registerAndSaveNewActor(gameObject);
     return gameObject;
+  }
+
+  private shouldConstructActorFully(actorDefinition: ActorDefinition): boolean {
+    const constructionState = actorDefinition.constructionSite?.state;
+    return constructionState === ConstructionStateEnum.Finished || constructionState === undefined;
   }
 
   public registerAndSaveNewActor(actor: Phaser.GameObjects.GameObject) {
@@ -184,14 +199,14 @@ export class SceneActorCreator {
     let actor: Phaser.GameObjects.GameObject | undefined = undefined;
     switch (faction) {
       case FactionType.Skaduwee:
-        FactionDefinitions.skaduwee.initialActors.forEach((actorName, index) => {
-          actor = this.createInitialActors(actorName, logicalSpawnPoint, owner_id, index, actor);
+        FactionDefinitions.skaduwee.initialActors.forEach((actorConfig, index) => {
+          actor = this.createInitialActors(actorConfig, logicalSpawnPoint, owner_id, index, actor);
         });
         break;
 
       case FactionType.Tivara:
-        FactionDefinitions.tivara.initialActors.forEach((actorName, index) => {
-          actor = this.createInitialActors(actorName, logicalSpawnPoint, owner_id, index, actor);
+        FactionDefinitions.tivara.initialActors.forEach((actorConfig, index) => {
+          actor = this.createInitialActors(actorConfig, logicalSpawnPoint, owner_id, index, actor);
         });
         break;
       default:
@@ -200,12 +215,15 @@ export class SceneActorCreator {
   }
 
   private createInitialActors(
-    actorName: ObjectNames,
+    actorConfig: InitialActorConfig,
     logicalSpawnPoint: Vector3Simple,
     owner_id: number,
     index: number,
     previouslyCreatedActor: Phaser.GameObjects.GameObject | undefined
   ): Phaser.GameObjects.GameObject | undefined {
+    const actorName = actorConfig.actorName;
+    const constructionState = actorConfig.constructionState ?? ConstructionStateEnum.Finished;
+
     const previouslyCreatedActorBounds = getGameObjectBounds(previouslyCreatedActor);
     let newX = logicalSpawnPoint.x + index * 160;
     if (previouslyCreatedActorBounds) {
@@ -228,7 +246,7 @@ export class SceneActorCreator {
         ownerId: owner_id
       },
       constructionSite: {
-        state: ConstructionStateEnum.Finished
+        state: constructionState
       }
     } satisfies ActorDefinition;
 

--- a/apps/client/src/app/probable-waffle/game/world/services/scene-actor-creator.ts
+++ b/apps/client/src/app/probable-waffle/game/world/services/scene-actor-creator.ts
@@ -23,6 +23,7 @@ import { getSceneService } from "./scene-component-helpers";
 import { ActorIndexSystem } from "./ActorIndexSystem";
 import { LoadGame } from "../../data/load-game";
 import type { InitialActorConfig } from "../../player/faction-info";
+import GameObject = Phaser.GameObjects.GameObject;
 
 export class SceneActorCreator {
   private readonly loadGame: LoadGame;
@@ -103,7 +104,7 @@ export class SceneActorCreator {
     if (!actorDefinition.name) return undefined;
 
     const shouldConstructFully = this.shouldConstructActorFully(actorDefinition);
-    let actor;
+    let actor: GameObject;
     if (shouldConstructFully) {
       actor = ActorManager.createActorFully(this.scene, actorDefinition.name as ObjectNames, actorDefinition);
     } else {

--- a/libs/api-interfaces/src/lib/communicators/probable-waffle/communicator-game-events.ts
+++ b/libs/api-interfaces/src/lib/communicators/probable-waffle/communicator-game-events.ts
@@ -1,8 +1,9 @@
 import { ConstructionStateEnum } from "./construction-state-enum";
+import type { ActorId } from "../../game-instance/player/player";
 
 export interface ProbableWaffleSelectionData {
   button: "left" | "right";
-  objectIds?: string[];
+  objectIds?: ActorId[];
   selectedArea?: { x: number; y: number; width: number; height: number };
   terrainSelectedTileVec3?: { x: number; y: number; z: number };
   terrainSelectedWorldVec3?: { x: number; y: number; z: number };
@@ -11,7 +12,7 @@ export interface ProbableWaffleSelectionData {
 }
 
 export interface ProbableWaffleDoubleSelectionData {
-  objectId: string;
+  objectId: ActorId;
 }
 
 export type HealthComponentData = {
@@ -21,4 +22,9 @@ export type HealthComponentData = {
 
 export type ConstructionSiteComponentData = {
   state: ConstructionStateEnum;
+  remainingConstructionTime: number;
+  progressPercentage: number;
+  assignedBuilders: ActorId[];
+  assignedRepairers: ActorId[];
+  playingBuildSound: boolean;
 };

--- a/libs/api-interfaces/src/lib/game-instance/player/player.ts
+++ b/libs/api-interfaces/src/lib/game-instance/player/player.ts
@@ -18,3 +18,4 @@ export abstract class BasePlayer<
 export type PlayerNumber = number;
 export type GameInstanceId = string;
 export type UserId = string;
+export type ActorId = string;

--- a/libs/api-interfaces/src/lib/game-instance/probable-waffle/component-data.ts
+++ b/libs/api-interfaces/src/lib/game-instance/probable-waffle/component-data.ts
@@ -17,8 +17,6 @@ export interface HealingComponentData {
 
 export interface BuilderComponentData {
   remainingCooldown?: number;
-  enterConstructionSite?: boolean;
-  constructionSiteOffset?: number;
   assignedConstructionSiteId?: string;
 }
 

--- a/libs/api-interfaces/src/lib/game-instance/probable-waffle/component-data.ts
+++ b/libs/api-interfaces/src/lib/game-instance/probable-waffle/component-data.ts
@@ -1,6 +1,7 @@
 import type { Vector3Simple } from "../../game/vector";
 import { ResourceType } from "../../probable-waffle/resource-type-definition";
 import { ObjectNames } from "./object-names";
+import type { ActorId } from "../player/player";
 
 export interface VisionComponentData {
   visibilityByCurrentPlayer?: boolean;
@@ -27,7 +28,7 @@ export interface GathererComponentData {
 }
 
 export interface ContainerComponentData {
-  containedIds?: string[];
+  containedIds?: ActorId[];
 }
 
 export interface ResourceDrainComponentData {
@@ -48,7 +49,7 @@ export interface ProductionComponentData {
 export interface RallyPointComponentData {
   tileVec3?: Vector3Simple;
   worldVec3?: Vector3Simple;
-  actorId?: string;
+  actorId?: ActorId;
 }
 
 export interface ActorTranslateComponentData {
@@ -90,7 +91,7 @@ export interface HousingComponentData {
 // Selection group data for save/load
 export interface SelectionGroupData {
   groupKey: number;
-  actorIds: string[];
+  actorIds: ActorId[];
   timestamp: number;
 }
 


### PR DESCRIPTION
## Changes
- handling how actors are resolved after load (awaiting before resolving ids from actorIndexSystem)
- saving whole construction site data so it can be re-loaded with correct progress after load
- allowing loading of non-fully-built actors
- added ActorId type
- Making definitions readonly  - type safety - so it's not misinterpreted like it was in builder-component
- Fixup distance check for builder component
- Disable LFS on PR and develop branches GHA
  -I reached LFS bandwidth on GH. THere's no need to have LFS running for codeql, test-on-pr. I also disabled it in develop as github pages should only get updated once it's merged to main