### PR TITLE
#544 Multiplayer game fixes

### DIFF
--- a/apps/api/src/app/probable-waffle/matchmaking/matchmaking.service.ts
+++ b/apps/api/src/app/probable-waffle/matchmaking/matchmaking.service.ts
@@ -7,6 +7,7 @@ import {
   GameSessionState,
   getRandomFactionType,
   type MapTuning,
+  MatchmakingTeamConfiguration,
   type PendingMatchmakingGameInstance,
   type PositionPlayerDefinition,
   ProbableWaffleGameInstance,
@@ -120,7 +121,12 @@ export class MatchmakingService implements MatchmakingServiceInterface {
   ) {
     const gameInstance = pendingMatchmakingGameInstance.gameInstance;
     // PLAYER:
-    const player = this.getNewPlayer(gameInstance, user.id, matchMakingDto.factionType);
+    const player = this.getNewPlayer(
+      gameInstance,
+      user.id,
+      matchMakingDto.factionType,
+      pendingMatchmakingGameInstance.teamConfiguration
+    );
     gameInstance.addPlayer(player);
     this.roomServerService.roomEvent("player.joined", gameInstance, user);
 
@@ -165,12 +171,14 @@ export class MatchmakingService implements MatchmakingServiceInterface {
       gameStateData: {} as ProbableWaffleGameStateData
     });
 
-    const player = this.getNewPlayer(newGameInstance, user.id, matchMakingDto.factionType);
+    const teamConfiguration = matchMakingDto.teamConfiguration ?? MatchmakingTeamConfiguration.FreeForAll;
+    const player = this.getNewPlayer(newGameInstance, user.id, matchMakingDto.factionType, teamConfiguration);
     newGameInstance.addPlayer(player);
 
     this.pendingMatchmakingGameInstances.push({
       gameInstance: newGameInstance,
-      commonMapPoolIds: matchMakingDto.mapPoolIds
+      commonMapPoolIds: matchMakingDto.mapPoolIds,
+      teamConfiguration
     });
     this.gameInstanceService.addGameInstance(newGameInstance, user);
 
@@ -183,10 +191,12 @@ export class MatchmakingService implements MatchmakingServiceInterface {
   private findGameInstanceForMatchMaking(
     matchMakingDto: RequestGameSearchForMatchMakingDto
   ): PendingMatchmakingGameInstance | null {
+    const requestedTeamConfig = matchMakingDto.teamConfiguration ?? MatchmakingTeamConfiguration.FreeForAll;
     const availableMatchmakingGameInstances = this.pendingMatchmakingGameInstances.filter(
       (gi) =>
         gi.gameInstance.gameInstanceMetadata.data.sessionState === GameSessionState.NotStarted &&
-        gi.gameInstance.gameInstanceMetadata.data.type === ProbableWaffleGameInstanceType.Matchmaking
+        gi.gameInstance.gameInstanceMetadata.data.type === ProbableWaffleGameInstanceType.Matchmaking &&
+        gi.teamConfiguration === requestedTeamConfig
     );
 
     // find game instance that has at least 1 map in common
@@ -208,20 +218,33 @@ export class MatchmakingService implements MatchmakingServiceInterface {
     return foundGameInstanceWithCommonMap ?? null;
   }
 
-  private getNewPlayer(gameInstance: ProbableWaffleGameInstance, userId: UserId, factionType: FactionType | null) {
+  private getNewPlayer(
+    gameInstance: ProbableWaffleGameInstance,
+    userId: UserId,
+    factionType: FactionType | null,
+    teamConfiguration: MatchmakingTeamConfiguration
+  ) {
     const randomFactionType = getRandomFactionType();
+    const playerNumber = gameInstance.players.length + 1;
+    const playerPosition = gameInstance.players.length;
+
+    // Calculate team based on team configuration
+    const team = this.calculateTeamNumber(playerPosition, teamConfiguration);
 
     console.log(
       "Ashes of the Ancients - New player",
-      gameInstance.players.length + 1,
+      playerNumber,
       "FactionType",
-      factionType ?? randomFactionType
+      factionType ?? randomFactionType,
+      "Team",
+      team
     );
 
     const playerDefinition = {
-      player: createPlayerLobbyDefinition(gameInstance.players.length + 1, gameInstance.players.length),
+      player: createPlayerLobbyDefinition(playerNumber, playerPosition),
       factionType: factionType ?? randomFactionType,
-      playerType: ProbableWafflePlayerType.Human
+      playerType: ProbableWafflePlayerType.Human,
+      team
     } satisfies PositionPlayerDefinition;
     // noinspection UnnecessaryLocalVariableJS
     const player = gameInstance.initPlayer({
@@ -255,5 +278,35 @@ export class MatchmakingService implements MatchmakingServiceInterface {
     this.pendingMatchmakingGameInstances = this.pendingMatchmakingGameInstances.filter(
       (gi) => gi.gameInstance.gameInstanceMetadata.data.gameInstanceId !== gameInstanceId
     );
+  }
+
+  /**
+   * Calculate team number based on player position and team configuration
+   * @param playerPosition - 0-indexed player position
+   * @param teamConfiguration - The team configuration mode
+   * @returns The team number (1-indexed)
+   */
+  private calculateTeamNumber(playerPosition: number, teamConfiguration: MatchmakingTeamConfiguration): number {
+    switch (teamConfiguration) {
+      case MatchmakingTeamConfiguration.FreeForAll:
+        // Each player gets their own team (1-indexed)
+        return playerPosition + 1;
+
+      case MatchmakingTeamConfiguration.TwoVsTwo:
+        // Players 0,1 are team 1, players 2,3 are team 2
+        return playerPosition < 2 ? 1 : 2;
+
+      case MatchmakingTeamConfiguration.ThreeVsThree:
+        // Players 0,1,2 are team 1, players 3,4,5 are team 2
+        return playerPosition < 3 ? 1 : 2;
+
+      case MatchmakingTeamConfiguration.FourVsFour:
+        // Players 0,1,2,3 are team 1, players 4,5,6,7 are team 2
+        return playerPosition < 4 ? 1 : 2;
+
+      default:
+        // Default to FFA behavior
+        return playerPosition + 1;
+    }
   }
 }

--- a/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.interface.ts
+++ b/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.interface.ts
@@ -51,4 +51,5 @@ export interface GameInstanceClientServiceInterface {
   loadGameInstance(gameInstanceSaveData: ProbableWaffleGameInstanceSaveData): Promise<void>;
   saveGameInstance(data: Record<string, any>): Promise<void>;
   startReplay(gameInstanceSaveData: ProbableWaffleGameInstanceSaveData): Promise<void>;
+  leaveLobby(): Promise<void>;
 }

--- a/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.stub.ts
+++ b/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.stub.ts
@@ -122,5 +122,8 @@ export const gameInstanceClientServiceStub = {
   },
   async startReplay(gameInstanceSaveData: ProbableWaffleGameInstanceSaveData): Promise<void> {
     return Promise.resolve();
+  },
+  async leaveLobby(): Promise<void> {
+    return Promise.resolve();
   }
 } satisfies GameInstanceClientServiceInterface;

--- a/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.ts
+++ b/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.ts
@@ -138,6 +138,7 @@ export class GameInstanceClientService implements GameInstanceClientServiceInter
               case GameSessionState.Stopped:
                 await this.stopListeningToGameInstanceEvents();
                 this.gameInstance = undefined;
+                this.currentPlayerNumber = undefined;
                 console.log("removed game instance");
                 break;
             }
@@ -664,5 +665,38 @@ export class GameInstanceClientService implements GameInstanceClientServiceInter
     if (this.externalModalRef) {
       this.externalModalRef.close();
     }
+  }
+
+  async leaveLobby(): Promise<void> {
+    // Remove current player or spectator from the game instance to notify others
+    if (this.currentPlayerNumber !== undefined) {
+      // Player is in the game, remove them
+      await this.removePlayer(this.currentPlayerNumber);
+    } else if (this.gameInstance?.spectators.some((s) => s.data.userId === this.authService.userId)) {
+      // Player is a spectator, remove them
+      await this.spectatorChanged("left", { userId: this.authService.userId! });
+    }
+
+    // For offline/skirmish games or if we're the host, stop the game instance completely
+    const isOffline = !this.authService.isAuthenticated || !this.serverHealthService.serverAvailable;
+    const isHost =
+      this.gameInstance?.gameInstanceMetadata?.data.createdBy === this.authService.userId;
+    const isSelfHosted =
+      this.gameInstance?.gameInstanceMetadata?.data.type === ProbableWaffleGameInstanceType.SelfHosted;
+    const isSkirmish =
+      this.gameInstance?.gameInstanceMetadata?.data.type === ProbableWaffleGameInstanceType.Skirmish;
+
+    if (isOffline || isSkirmish || (isSelfHosted && isHost)) {
+      // Stop the entire game instance
+      await this.stopGameInstance();
+    } else {
+      // Just clean up local state without stopping the server instance
+      await this.stopListeningToGameInstanceEvents();
+      this.gameInstance = undefined;
+      this.currentPlayerNumber = undefined;
+    }
+
+    // Navigate away
+    await this.router.navigate(["aota"]);
   }
 }

--- a/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.ts
+++ b/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.ts
@@ -668,35 +668,59 @@ export class GameInstanceClientService implements GameInstanceClientServiceInter
   }
 
   async leaveLobby(): Promise<void> {
-    // Remove current player or spectator from the game instance to notify others
+    const isSelfHosted =
+      this.gameInstance?.gameInstanceMetadata?.data.type === ProbableWaffleGameInstanceType.SelfHosted;
+    const isSkirmish = this.gameInstance?.gameInstanceMetadata?.data.type === ProbableWaffleGameInstanceType.Skirmish;
+    const isOffline = !this.authService.isAuthenticated || !this.serverHealthService.serverAvailable;
+    const isHost = this.gameInstance?.gameInstanceMetadata?.data.createdBy === this.authService.userId;
+
+    // Handle player or spectator leaving
     if (this.currentPlayerNumber !== undefined) {
-      // Player is in the game, remove them
-      await this.removePlayer(this.currentPlayerNumber);
+      // Convert player slot back to NetworkOpen for multiplayer games
+      if (isSelfHosted) {
+        // Player is in the game, remove them
+        await this.removePlayer(this.currentPlayerNumber);
+      }
     } else if (this.gameInstance?.spectators.some((s) => s.data.userId === this.authService.userId)) {
       // Player is a spectator, remove them
       await this.spectatorChanged("left", { userId: this.authService.userId! });
     }
 
-    // For offline/skirmish games or if we're the host, stop the game instance completely
-    const isOffline = !this.authService.isAuthenticated || !this.serverHealthService.serverAvailable;
-    const isHost =
-      this.gameInstance?.gameInstanceMetadata?.data.createdBy === this.authService.userId;
-    const isSelfHosted =
-      this.gameInstance?.gameInstanceMetadata?.data.type === ProbableWaffleGameInstanceType.SelfHosted;
-    const isSkirmish =
-      this.gameInstance?.gameInstanceMetadata?.data.type === ProbableWaffleGameInstanceType.Skirmish;
+    // Handle host transfer or game instance shutdown
+    if (isSelfHosted && isHost) {
+      // Find the earliest joined human player to transfer ownership to
+      const humanPlayers =
+        this.gameInstance?.players.filter(
+          (p) =>
+            p.playerController.data.playerDefinition?.playerType === ProbableWafflePlayerType.Human &&
+            p.playerController.data.userId !== this.authService.userId &&
+            p.playerController.data.userId !== null
+        ) || [];
 
-    if (isOffline || isSkirmish || (isSelfHosted && isHost)) {
-      // Stop the entire game instance
+      if (humanPlayers.length > 0) {
+        // Transfer ownership to the first human player
+        const newHost = humanPlayers[0]!;
+        const newHostUserId = newHost.playerController.data.userId!;
+
+        await this.gameInstanceMetadataChanged("createdBy", { createdBy: newHostUserId });
+
+        // Clean up local state and navigate away
+        await this.stopListeningToGameInstanceEvents();
+        this.gameInstance = undefined;
+        this.currentPlayerNumber = undefined;
+      } else {
+        // No human players left, destroy the game instance
+        await this.stopGameInstance();
+      }
+    } else if (isOffline || isSkirmish) {
+      // Stop the entire game instance for offline/skirmish
       await this.stopGameInstance();
     } else {
-      // Just clean up local state without stopping the server instance
+      // Just clean up local state without stopping the server instance (non-host player leaving)
       await this.stopListeningToGameInstanceEvents();
       this.gameInstance = undefined;
       this.currentPlayerNumber = undefined;
     }
-
-    // Navigate away
     await this.router.navigate(["aota"]);
   }
 }

--- a/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.ts
+++ b/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.ts
@@ -622,7 +622,8 @@ export class GameInstanceClientService implements GameInstanceClientServiceInter
     const url = environment.api + "api/probable-waffle/matchmaking/request-game-search-for-matchmaking";
     const body: RequestGameSearchForMatchMakingDto = {
       mapPoolIds: matchmakingOptions.levels.filter((l) => l.checked).map((l) => l.id),
-      factionType: matchmakingOptions.factionType
+      factionType: matchmakingOptions.factionType,
+      teamConfiguration: matchmakingOptions.teamConfiguration
     };
     await firstValueFrom(this.httpClient.post<void>(url, body));
   }

--- a/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.ts
+++ b/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.ts
@@ -675,53 +675,53 @@ export class GameInstanceClientService implements GameInstanceClientServiceInter
     const isOffline = !this.authService.isAuthenticated || !this.serverHealthService.serverAvailable;
     const isHost = this.gameInstance?.gameInstanceMetadata?.data.createdBy === this.authService.userId;
 
-    // Handle player or spectator leaving
+    await this.handlePlayerOrSpectatorLeaving();
+
+    if (isSelfHosted && isHost) {
+      await this.handleHostLeavingSelfHostedGame();
+    } else if (isOffline || isSkirmish) {
+      await this.stopGameInstance();
+    } else {
+      await this.cleanupLocalGameState();
+    }
+
+    await this.router.navigate(["aota"]);
+  }
+
+  private async handlePlayerOrSpectatorLeaving(): Promise<void> {
     if (this.currentPlayerNumber !== undefined) {
-      // Convert player slot back to NetworkOpen for multiplayer games
+      const isSelfHosted =
+        this.gameInstance?.gameInstanceMetadata?.data.type === ProbableWaffleGameInstanceType.SelfHosted;
       if (isSelfHosted) {
-        // Player is in the game, remove them
         await this.removePlayer(this.currentPlayerNumber);
       }
     } else if (this.gameInstance?.spectators.some((s) => s.data.userId === this.authService.userId)) {
-      // Player is a spectator, remove them
       await this.spectatorChanged("left", { userId: this.authService.userId! });
     }
+  }
 
-    // Handle host transfer or game instance shutdown
-    if (isSelfHosted && isHost) {
-      // Find the earliest joined human player to transfer ownership to
-      const humanPlayers =
-        this.gameInstance?.players.filter(
-          (p) =>
-            p.playerController.data.playerDefinition?.playerType === ProbableWafflePlayerType.Human &&
-            p.playerController.data.userId !== this.authService.userId &&
-            p.playerController.data.userId !== null
-        ) || [];
+  private async handleHostLeavingSelfHostedGame(): Promise<void> {
+    const humanPlayers =
+      this.gameInstance?.players.filter(
+        (p) =>
+          p.playerController.data.playerDefinition?.playerType === ProbableWafflePlayerType.Human &&
+          p.playerController.data.userId !== this.authService.userId &&
+          p.playerController.data.userId !== null
+      ) || [];
 
-      if (humanPlayers.length > 0) {
-        // Transfer ownership to the first human player
-        const newHost = humanPlayers[0]!;
-        const newHostUserId = newHost.playerController.data.userId!;
-
-        await this.gameInstanceMetadataChanged("createdBy", { createdBy: newHostUserId });
-
-        // Clean up local state and navigate away
-        await this.stopListeningToGameInstanceEvents();
-        this.gameInstance = undefined;
-        this.currentPlayerNumber = undefined;
-      } else {
-        // No human players left, destroy the game instance
-        await this.stopGameInstance();
-      }
-    } else if (isOffline || isSkirmish) {
-      // Stop the entire game instance for offline/skirmish
-      await this.stopGameInstance();
+    if (humanPlayers.length > 0) {
+      const newHost = humanPlayers[0]!;
+      const newHostUserId = newHost.playerController.data.userId!;
+      await this.gameInstanceMetadataChanged("createdBy", { createdBy: newHostUserId });
+      await this.cleanupLocalGameState();
     } else {
-      // Just clean up local state without stopping the server instance (non-host player leaving)
-      await this.stopListeningToGameInstanceEvents();
-      this.gameInstance = undefined;
-      this.currentPlayerNumber = undefined;
+      await this.stopGameInstance();
     }
-    await this.router.navigate(["aota"]);
+  }
+
+  private async cleanupLocalGameState(): Promise<void> {
+    await this.stopListeningToGameInstanceEvents();
+    this.gameInstance = undefined;
+    this.currentPlayerNumber = undefined;
   }
 }

--- a/apps/client/src/app/probable-waffle/communicators/rooms/rooms.service.ts
+++ b/apps/client/src/app/probable-waffle/communicators/rooms/rooms.service.ts
@@ -22,6 +22,7 @@ import { type RoomsServiceInterface } from "./rooms.service.interface";
 })
 export class RoomsService implements RoomsServiceInterface {
   private roomsSubscription?: Subscription;
+  private isInitialized = false;
   rooms = signal<ProbableWaffleRoom[]>([]);
 
   private readonly authService = inject(AuthService);
@@ -56,7 +57,13 @@ export class RoomsService implements RoomsServiceInterface {
    */
   async listenToRoomEvents() {
     const roomEvent = await this.getRoomEvent();
-    this.roomsSubscription = roomEvent?.subscribe(async (roomEvent) => {
+    if (!roomEvent) {
+      console.error("[RoomsService] Failed to get room event observable - socket may not be connected");
+      return;
+    }
+    // console.log("[RoomsService] Subscribing to room events");
+    this.roomsSubscription = roomEvent.subscribe(async (roomEvent) => {
+      // console.log("[RoomsService] Room event received:", roomEvent.action, roomEvent.room.gameInstanceMetadataData.gameInstanceId);
       const room = roomEvent.room;
       const rooms = this.rooms();
       const roomLocally = rooms.find(
@@ -64,9 +71,11 @@ export class RoomsService implements RoomsServiceInterface {
       );
       switch (roomEvent.action) {
         case "added":
+          // console.log("[RoomsService] Adding room:", room.gameInstanceMetadataData.gameInstanceId);
           this.rooms.update((rooms) => [...rooms, room]);
           break;
         case "removed":
+          // console.log("[RoomsService] Removing room:", room.gameInstanceMetadataData.gameInstanceId);
           this.rooms.update((rooms) =>
             rooms.filter(
               (room) =>
@@ -80,7 +89,14 @@ export class RoomsService implements RoomsServiceInterface {
         case "spectator.left":
         case "game_instance_metadata":
         case "game_mode":
-          if (!roomLocally) return;
+          if (!roomLocally) {
+            console.warn(
+              "[RoomsService] Received update for room not in local list:",
+              room.gameInstanceMetadataData.gameInstanceId
+            );
+            return;
+          }
+          // console.log("[RoomsService] Updating room:", room.gameInstanceMetadataData.gameInstanceId);
           roomLocally.gameInstanceMetadataData = roomEvent.room.gameInstanceMetadataData;
           roomLocally.gameModeData = roomEvent.room.gameModeData;
           roomLocally.players = roomEvent.room.players;
@@ -94,21 +110,43 @@ export class RoomsService implements RoomsServiceInterface {
   }
 
   async getRooms(maps: ProbableWaffleMapEnum[] | null = null): Promise<ProbableWaffleRoom[]> {
-    if (!this.authService.isAuthenticated || !this.serverHealthService.serverAvailable) return [];
+    if (!this.authService.isAuthenticated || !this.serverHealthService.serverAvailable) {
+      console.warn("[RoomsService] Cannot fetch rooms - not authenticated or server unavailable");
+      return [];
+    }
     const url = environment.api + "api/probable-waffle/get-rooms";
     const body: ProbableWaffleGetRoomsDto = {
       maps: maps
     };
-    return await firstValueFrom(this.httpClient.post<ProbableWaffleRoom[]>(url, body));
+    try {
+      // noinspection UnnecessaryLocalVariableJS
+      const rooms = await firstValueFrom(this.httpClient.post<ProbableWaffleRoom[]>(url, body));
+      // console.log("[RoomsService] Fetched rooms:", rooms.length);
+      return rooms;
+    } catch (error) {
+      console.error("[RoomsService] Failed to fetch rooms:", error);
+      return [];
+    }
   }
 
   async init(): Promise<void> {
+    // If already initialized and subscribed, just refresh the rooms
+    if (this.isInitialized && this.roomsSubscription && !this.roomsSubscription.closed) {
+      // console.log("[RoomsService] Already initialized, refreshing rooms");
+      await this.initiallyPullRooms();
+      return;
+    }
+
+    // console.log("[RoomsService] Initializing rooms service");
     await this.initiallyPullRooms();
     await this.listenToRoomEvents();
+    this.isInitialized = true;
   }
 
   async initiallyPullRooms(): Promise<void> {
-    this.rooms.set(await this.getRooms());
+    const rooms = await this.getRooms();
+    this.rooms.set(rooms);
+    // console.log("[RoomsService] Set rooms to:", rooms.length);
   }
 
   private async getRoomEvent(): Promise<Observable<ProbableWaffleRoomEvent> | undefined> {
@@ -119,7 +157,9 @@ export class RoomsService implements RoomsServiceInterface {
   }
 
   destroy(): void {
+    // console.log("[RoomsService] Destroy called - unsubscribing from room events");
     this.roomsSubscription?.unsubscribe();
-    this.rooms.set([]);
+    // Don't clear rooms since this is a singleton service
+    // Rooms will be refreshed on next init()
   }
 }

--- a/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/movement.system.ts
@@ -364,7 +364,7 @@ export class MovementSystem {
     onComplete?: (() => void) | (() => Promise<void>),
     onStop?: () => void
   ): Promise<void> {
-    if (!this.gameObject.scene.scene.isActive()) {
+    if (!this.gameObject.scene || !this.gameObject.scene.scene.isActive()) {
       return Promise.reject("Scene is not active");
     }
     const tileWorldXY = this.navigationService?.getTileWorldCenter(tile);

--- a/apps/client/src/app/probable-waffle/game/library/distance-helper.ts
+++ b/apps/client/src/app/probable-waffle/game/library/distance-helper.ts
@@ -327,6 +327,8 @@ export class DistanceHelper {
 
       for (const { pair, index } of scenePairs) {
         const [actor1, actor2] = pair;
+        if(!actor1.scene || !actor2.scene) continue;
+
         const actor1Tile = getGameObjectCurrentTile(actor1);
         const actor2Tile = getGameObjectCurrentTile(actor2);
         if (!actor1Tile || !actor2Tile) continue;

--- a/apps/client/src/app/probable-waffle/game/world/state/GameModeConditionChecker.ts
+++ b/apps/client/src/app/probable-waffle/game/world/state/GameModeConditionChecker.ts
@@ -40,6 +40,7 @@ export class GameModeConditionChecker {
   private stopped: boolean = false;
   private surrenderCheckInterval = 2000; // Check every 2 seconds
   private lastSurrenderCheckTime = 0;
+  private currentDelay?: Phaser.Time.TimerEvent;
 
   constructor(private readonly scene: ProbableWaffleScene) {
     const gameModeData = getGameModeFromScene<ProbableWaffleGameMode>(scene).data;
@@ -47,9 +48,13 @@ export class GameModeConditionChecker {
     this.winConditions = gameModeData.winConditions;
     this.tieConditions = gameModeData.tieConditions;
 
-    this.scene.events.on(Phaser.Scenes.Events.UPDATE, this.throttleCheck, this);
+    this.currentDelay = this.scene.time.delayedCall(1000, this.startChecking, [], this);
     this.scene.events.once(Phaser.Scenes.Events.SHUTDOWN, this.destroy, this);
     this.listenToPlayerQuit();
+  }
+
+  private startChecking() {
+    this.scene.events.on(Phaser.Scenes.Events.UPDATE, this.throttleCheck, this);
   }
 
   private throttleCheck = throttle(this.check.bind(this), 1000);
@@ -369,5 +374,6 @@ export class GameModeConditionChecker {
     this.scene.events.off(Phaser.Scenes.Events.UPDATE, this.throttleCheck);
     this.scene.events.off(Phaser.Scenes.Events.SHUTDOWN, this.destroy);
     this.selfQuitSubscription?.unsubscribe();
+    this.currentDelay?.destroy();
   }
 }

--- a/apps/client/src/app/probable-waffle/gui/lobby/lobby.component.ts
+++ b/apps/client/src/app/probable-waffle/gui/lobby/lobby.component.ts
@@ -68,8 +68,8 @@ export class LobbyComponent implements OnInit {
     );
   }
 
-  leaveLobby() {
-    this.router.navigate(["aota"]);
+  async leaveLobby() {
+    await this.gameInstanceClientService.leaveLobby();
   }
 
   deselectMap() {

--- a/apps/client/src/app/probable-waffle/gui/online/matchmaking/matchmaking-options.ts
+++ b/apps/client/src/app/probable-waffle/gui/online/matchmaking/matchmaking-options.ts
@@ -1,8 +1,9 @@
-import { FactionType } from "@fuzzy-waddle/api-interfaces";
+import { FactionType, MatchmakingTeamConfiguration } from "@fuzzy-waddle/api-interfaces";
 import type { MatchmakingLevel } from "./matchmaking-level";
 
 export type MatchmakingOptions = {
   factionType: FactionType | null;
   nrOfPlayers: number;
+  teamConfiguration: MatchmakingTeamConfiguration;
   levels: MatchmakingLevel[];
 };

--- a/apps/client/src/app/probable-waffle/gui/online/matchmaking/matchmaking.component.html
+++ b/apps/client/src/app/probable-waffle/gui/online/matchmaking/matchmaking.component.html
@@ -14,6 +14,21 @@
     }
   </div>
   <div>
+    <div class="general-title">Team Configuration</div>
+    <div class="text-center">
+      @for (teamConfig of matchmakingService.availableTeamConfigurations; track teamConfig) {
+        <input
+          (change)="matchmakingService.teamConfigurationChanged(teamConfig)"
+          [disabled]="matchmakingService.searching"
+          [checked]="teamConfig === matchmakingService.matchmakingOptions.teamConfiguration"
+          name="teamConfiguration"
+          type="radio"
+          [value]="teamConfig"
+        />&nbsp;{{ matchmakingService.getTeamConfigurationName(teamConfig) }}&nbsp;&nbsp;
+      }
+    </div>
+  </div>
+  <div>
     <div class="general-title">Faction</div>
     <div class="text-center">
       <select

--- a/apps/client/src/app/probable-waffle/gui/online/matchmaking/matchmaking.service.ts
+++ b/apps/client/src/app/probable-waffle/gui/online/matchmaking/matchmaking.service.ts
@@ -2,7 +2,12 @@ import { inject, Injectable } from "@angular/core";
 import { Subscription } from "rxjs";
 import { GameInstanceClientService } from "../../../communicators/game-instance-client.service";
 import { RoomsService } from "../../../communicators/rooms/rooms.service";
-import { FactionType, type ProbableWaffleGameFoundEvent, ProbableWaffleLevels } from "@fuzzy-waddle/api-interfaces";
+import {
+  FactionType,
+  MatchmakingTeamConfiguration,
+  type ProbableWaffleGameFoundEvent,
+  ProbableWaffleLevels
+} from "@fuzzy-waddle/api-interfaces";
 import { type IMatchmakingService } from "./matchmaking.service.interface";
 import { environment } from "../../../../../environments/environment";
 import type { MatchmakingLevel } from "./matchmaking-level";
@@ -28,6 +33,7 @@ export class MatchmakingService implements IMatchmakingService {
     this.matchmakingOptions = {
       factionType: this.lastPlayedFactionType,
       nrOfPlayers: firstNrOfPlayersOption,
+      teamConfiguration: MatchmakingTeamConfiguration.FreeForAll,
       levels: this.levels
     };
     this.nrOfPlayersChanged(firstNrOfPlayersOption);
@@ -116,11 +122,85 @@ export class MatchmakingService implements IMatchmakingService {
 
   nrOfPlayersChanged(nr: number) {
     this.matchmakingOptions.nrOfPlayers = nr;
+    // Reset to FFA if invalid team configuration for this player count
+    if (!this.isTeamConfigurationValidForPlayerCount(this.matchmakingOptions.teamConfiguration, nr)) {
+      this.matchmakingOptions.teamConfiguration = MatchmakingTeamConfiguration.FreeForAll;
+    }
+    this.updateMapAvailability();
+  }
+
+  teamConfigurationChanged(teamConfig: MatchmakingTeamConfiguration) {
+    this.matchmakingOptions.teamConfiguration = teamConfig;
+    this.updateMapAvailability();
+  }
+
+  /**
+   * Update map availability based on current player count and team configuration
+   */
+  private updateMapAvailability() {
     const nrOfPlayers = this.matchmakingOptions.nrOfPlayers;
     this.matchmakingOptions.levels.forEach((level) => {
       level.enabled = level.nrOfPlayers === nrOfPlayers;
       level.checked = level.enabled;
     });
+  }
+
+  /**
+   * Get available team configurations for the current player count
+   */
+  get availableTeamConfigurations(): MatchmakingTeamConfiguration[] {
+    const nrOfPlayers = this.matchmakingOptions.nrOfPlayers;
+    const configs: MatchmakingTeamConfiguration[] = [MatchmakingTeamConfiguration.FreeForAll];
+
+    // Only add team modes for valid player counts
+    if (nrOfPlayers === 4) {
+      configs.push(MatchmakingTeamConfiguration.TwoVsTwo);
+    } else if (nrOfPlayers === 6) {
+      configs.push(MatchmakingTeamConfiguration.ThreeVsThree);
+    } else if (nrOfPlayers === 8) {
+      configs.push(MatchmakingTeamConfiguration.FourVsFour);
+    }
+
+    return configs;
+  }
+
+  /**
+   * Check if a team configuration is valid for a given player count
+   */
+  private isTeamConfigurationValidForPlayerCount(
+    teamConfig: MatchmakingTeamConfiguration,
+    playerCount: number
+  ): boolean {
+    switch (teamConfig) {
+      case MatchmakingTeamConfiguration.FreeForAll:
+        return true; // Always valid
+      case MatchmakingTeamConfiguration.TwoVsTwo:
+        return playerCount === 4;
+      case MatchmakingTeamConfiguration.ThreeVsThree:
+        return playerCount === 6;
+      case MatchmakingTeamConfiguration.FourVsFour:
+        return playerCount === 8;
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * Get display name for team configuration
+   */
+  getTeamConfigurationName(config: MatchmakingTeamConfiguration): string {
+    switch (config) {
+      case MatchmakingTeamConfiguration.FreeForAll:
+        return "Free For All";
+      case MatchmakingTeamConfiguration.TwoVsTwo:
+        return "2v2";
+      case MatchmakingTeamConfiguration.ThreeVsThree:
+        return "3v3";
+      case MatchmakingTeamConfiguration.FourVsFour:
+        return "4v4";
+      default:
+        return config;
+    }
   }
 
   checkedChanged(level: MatchmakingLevel) {

--- a/libs/api-interfaces/src/lib/communicators/probable-waffle/listeners.ts
+++ b/libs/api-interfaces/src/lib/communicators/probable-waffle/listeners.ts
@@ -41,6 +41,9 @@ export class ProbableWaffleListeners {
             throw new Error("Unknown session state: " + payload.data.sessionState);
         }
         break;
+      case "createdBy":
+        gameInstance.gameInstanceMetadata!.data.createdBy = payload.data.createdBy!;
+        break;
       default:
         throw new Error("Unknown communicator for gameInstanceMetadataDataChange: " + payload.property);
     }

--- a/libs/api-interfaces/src/lib/probable-waffle/probable-waffle-api.ts
+++ b/libs/api-interfaces/src/lib/probable-waffle/probable-waffle-api.ts
@@ -49,6 +49,14 @@ export interface ProbableWafflePlayerLeftDto extends GameInstanceDataDto {
 export interface RequestGameSearchForMatchMakingDto {
   mapPoolIds: number[];
   factionType: FactionType | null;
+  teamConfiguration?: MatchmakingTeamConfiguration;
+}
+
+export enum MatchmakingTeamConfiguration {
+  FreeForAll = "FFA", // Each player on their own team
+  TwoVsTwo = "2v2", // 2 teams of 2 players
+  ThreeVsThree = "3v3", // 2 teams of 3 players
+  FourVsFour = "4v4" // 2 teams of 4 players
 }
 
 export enum ProbableWaffleGatewayRoomTypes {
@@ -58,6 +66,7 @@ export enum ProbableWaffleGatewayRoomTypes {
 export interface PendingMatchmakingGameInstance {
   gameInstance: ProbableWaffleGameInstance;
   commonMapPoolIds: number[];
+  teamConfiguration: MatchmakingTeamConfiguration;
 }
 
 export interface ProbableWaffleGameInstanceSaveData {


### PR DESCRIPTION
## Changes
- fixed issue when refreshing page on "online" page where lobby was opened but if you refreshed the page it didn't work
- fixed "leave lobby" for second player
- fixed "leave lobby" for host - transfering ownership to first-joined human player
- fixing some scene-destroyed checks
- deferring win/lose checker
- team configuration for matchmaking:
  - this fixes the issue where both players were assigned to the same team
  - added 4 game modes: FFA, 2v2, 3v3, 4v4