### PR TITLE
#524 Research component queue fixes

### DIFF
--- a/apps/client/src/app/probable-waffle/game/data/actor-manager.spec.ts
+++ b/apps/client/src/app/probable-waffle/game/data/actor-manager.spec.ts
@@ -3,7 +3,7 @@ import { ObjectNames } from "@fuzzy-waddle/api-interfaces";
 
 describe("ActorManager", () => {
   describe("actorMap", () => {
-    it("should contain all ObjectNames enum values", () => {
+    it("All ObjectNames should be contained in ActorManager", () => {
       const enumValues = Object.values(ObjectNames);
       const missingActors: string[] = [];
 

--- a/apps/client/src/app/probable-waffle/game/data/actor-manager.ts
+++ b/apps/client/src/app/probable-waffle/game/data/actor-manager.ts
@@ -68,6 +68,7 @@ import Boar from "../prefabs/animals/boar/Boar";
 import Stag from "../prefabs/animals/stag/Stag";
 import Badger from "../prefabs/animals/badger/Badger";
 import { RandomService } from "../world/services/random.service";
+import HealingTotem from "../prefabs/buildings/tivara/HealingTotem/HealingTotem";
 
 type ActorMap = { [name: string]: new (scene: Phaser.Scene) => GameObject };
 export class ActorManager {
@@ -144,6 +145,10 @@ export class ActorManager {
     [ObjectNames.StonePile]: StonePile
   };
 
+  private static spells: ActorMap = {
+    [ObjectNames.HealingTotem]: HealingTotem
+  };
+
   public static actorMap: ActorMap = {
     ...ActorManager.animals,
     ...ActorManager.general,
@@ -153,7 +158,8 @@ export class ActorManager {
     ...ActorManager.skaduweeWorkers,
     ...ActorManager.skaduweeUnits,
     ...ActorManager.skaduweeBuildings,
-    ...ActorManager.resources
+    ...ActorManager.resources,
+    ...ActorManager.spells
   } as const;
 
   static getActorDefinitionFromActor(actor: GameObject): ActorDefinition | undefined {

--- a/apps/client/src/app/probable-waffle/game/prefabs/gui/buttons/ActorActions.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/gui/buttons/ActorActions.ts
@@ -215,6 +215,8 @@ export default class ActorActions extends Phaser.GameObjects.Container {
   private resourceChangedSubscription?: Subscription;
   private actorUnlockSubscription?: Subscription;
   private researchEventSubscriptions: Subscription[] = [];
+  private spellCooldownSubscriptions: Subscription[] = [];
+  private spellUpdateTimer?: Phaser.Time.TimerEvent;
 
   /** Subscribe to selection changes and update displayed actions accordingly */
   private subscribeToPlayerSelection() {
@@ -242,6 +244,7 @@ export default class ActorActions extends Phaser.GameObjects.Container {
         this.subscribeToResourceChanges();
         this.subscribeToActorUnlockEvents();
         this.subscribeToResearchChanges();
+        this.subscribeToSpellCooldowns(actor);
       }
     });
 
@@ -299,6 +302,7 @@ export default class ActorActions extends Phaser.GameObjects.Container {
       action.setup({ visible: false });
     });
     this.resourceChangedSubscription?.unsubscribe();
+    this.stopSpellCooldownTimer();
   }
 
   private subscribeToActorKillEvent(actor: Phaser.GameObjects.GameObject) {
@@ -1290,6 +1294,63 @@ export default class ActorActions extends Phaser.GameObjects.Container {
     return { disabled, disabledDescription, validation };
   }
 
+  /** Subscribe to the selected actor's spell cooldown events and drive a refresh timer */
+  private subscribeToSpellCooldowns(actor: Phaser.GameObjects.GameObject) {
+    this.spellCooldownSubscriptions.forEach((sub) => sub.unsubscribe());
+    this.spellCooldownSubscriptions = [];
+    this.stopSpellCooldownTimer();
+
+    const spellComponent = getActorComponent(actor, SpellComponent);
+    if (!spellComponent) return;
+
+    // Start the timer when a cooldown begins
+    const startedSub = spellComponent.spellCooldownStarted.subscribe(() => {
+      this.startSpellCooldownTimer(spellComponent);
+    });
+    this.spellCooldownSubscriptions.push(startedSub);
+
+    // Stop the timer when the last cooldown expires
+    const endedSub = spellComponent.spellCooldownEnded.subscribe(() => {
+      const stillActive = spellComponent.availableSpells.some((s) => spellComponent.getCooldownRemaining(s) > 0);
+      if (!stillActive) {
+        this.stopSpellCooldownTimer();
+        // Final refresh to clear the cooldown overlays
+        this.refreshForCurrentSelection();
+      }
+    });
+    this.spellCooldownSubscriptions.push(endedSub);
+
+    // If there are already active cooldowns when the actor is selected, start timer immediately
+    const hasActiveCooldowns = spellComponent.availableSpells.some((s) => spellComponent.getCooldownRemaining(s) > 0);
+    if (hasActiveCooldowns) {
+      this.startSpellCooldownTimer(spellComponent);
+    }
+  }
+
+  private startSpellCooldownTimer(spellComponent: SpellComponent) {
+    if (this.spellUpdateTimer) return; // Already running
+
+    this.spellUpdateTimer = this.mainSceneWithActors.time.addEvent({
+      delay: 100,
+      loop: true,
+      callback: () => {
+        // Stop if no more active cooldowns
+        const stillActive = spellComponent?.availableSpells.some((s) => spellComponent.getCooldownRemaining(s) > 0);
+        if (!stillActive) {
+          this.stopSpellCooldownTimer();
+          this.refreshForCurrentSelection();
+          return;
+        }
+        this.refreshForCurrentSelection();
+      }
+    });
+  }
+
+  private stopSpellCooldownTimer() {
+    this.spellUpdateTimer?.remove(false);
+    this.spellUpdateTimer = undefined;
+  }
+
   /** Check if a spell can be cast (cooldown, mana, research requirements) */
   private getSpellValidationState(
     spellType: SpellType,
@@ -1374,6 +1435,8 @@ export default class ActorActions extends Phaser.GameObjects.Container {
     this.resourceChangedSubscription?.unsubscribe();
     this.actorUnlockSubscription?.unsubscribe();
     this.researchEventSubscriptions.forEach((sub) => sub.unsubscribe());
+    this.spellCooldownSubscriptions.forEach((sub) => sub.unsubscribe());
+    this.stopSpellCooldownTimer();
     this.categoryNavigationStack = [];
     this.tabHandlerSubscription?.unsubscribe();
     this.mainSceneWithActors.events.off(

--- a/apps/client/src/app/probable-waffle/game/prefabs/gui/buttons/ActorActions.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/gui/buttons/ActorActions.ts
@@ -49,6 +49,8 @@ import { SpellCursor } from "../../../player/human-controller/spell-cursor";
 import type { SpellType } from "../../../entity/components/combat/spell-type";
 import { ResearchComponent } from "../../../entity/components/research/research-component";
 import { researchDefinitions } from "../../../entity/components/research/research-definitions";
+import { QueueComponent } from "../../../entity/components/queue/queue-component";
+import { QueueItemType } from "../../../entity/components/queue/queue-item";
 /* END-USER-IMPORTS */
 
 /**
@@ -723,6 +725,13 @@ export default class ActorActions extends Phaser.GameObjects.Container {
       const spellData = spellDefinitions[spellType];
       if (!spellData) return;
 
+      const isResearched = spellComponent.isSpellResearched(spellType);
+
+      // Hide spells that require research but haven't been researched yet
+      if (!isResearched && spellData.requiresResearch) {
+        return;
+      }
+
       const action = this.actor_actions[index];
       if (!action) {
         console.error("Action button not found at index", index);
@@ -732,7 +741,6 @@ export default class ActorActions extends Phaser.GameObjects.Container {
       const cooldownProgress = spellComponent.getCooldownProgress(spellType);
       const cooldownRemaining = spellComponent.getCooldownRemaining(spellType);
       const autocastEnabled = spellComponent.isAutocastEnabled(spellType);
-      const isResearched = spellComponent.isSpellResearched(spellType);
 
       // Use validation state similar to production
       const { disabled, unmetRequirements } = this.getSpellValidationState(spellType, spellComponent);
@@ -907,9 +915,6 @@ export default class ActorActions extends Phaser.GameObjects.Container {
     const researchComponent = getActorComponent(actor, ResearchComponent);
     if (!researchComponent) return index;
 
-    // Check if any research is in progress globally (across all player's buildings)
-    const isResearchInProgressGlobally = this.isResearchInProgressGlobally();
-
     for (const researchType of researchComponent.availableResearch) {
       const researchData = researchDefinitions[researchType];
       if (!researchData) continue;
@@ -920,18 +925,26 @@ export default class ActorActions extends Phaser.GameObjects.Container {
         return index;
       }
 
+      // Skip if already fully completed in TechTree
       const isAlreadyResearched = researchComponent.isResearched(researchType);
-      const isCurrentlyResearching = researchComponent.currentResearchType === researchType;
-      const progress = researchComponent.getResearchProgress(researchType);
-
-      // Skip already researched items
       if (isAlreadyResearched) continue;
 
-      // Skip if any other research is in progress globally (only one research at a time)
-      if (isResearchInProgressGlobally && !isCurrentlyResearching) continue;
+      // Is this research currently the active (first) item being processed in this building?
+      const isActiveInThisBuilding = researchComponent.currentResearchType === researchType;
+      const progress = isActiveInThisBuilding ? researchComponent.getResearchProgress(researchType) : 0;
 
-      // Use validation state similar to production
-      const { disabled, unmetRequirements } = this.getResearchValidationState(researchType, researchComponent);
+      // Is this research already queued anywhere (this or another building)?
+      const isQueuedGlobally = this.isResearchTypeQueuedGlobally(researchType);
+
+      // Validation state (resources, prerequisites) - only relevant when not yet queued
+      const { disabled: isValidationDisabled, unmetRequirements } = this.getResearchValidationState(
+        researchType,
+        researchComponent
+      );
+
+      // Disable if already in queue globally or if validation fails
+      // But keep it interactable (not disabled) if it's the active item - so the player can cancel
+      const disabled = isQueuedGlobally || isValidationDisabled;
 
       action.setup({
         icon: {
@@ -940,15 +953,15 @@ export default class ActorActions extends Phaser.GameObjects.Container {
           origin: { x: 0.5, y: 0.5 }
         },
         visible: true,
-        disabled: disabled && !isCurrentlyResearching,
-        cooldownProgress: isCurrentlyResearching ? progress : undefined,
+        disabled: disabled && !isActiveInThisBuilding,
+        cooldownProgress: isActiveInThisBuilding ? progress : undefined,
         action: () => {
-          if (isCurrentlyResearching) {
-            // Cancel research
+          if (isActiveInThisBuilding) {
+            // Cancel the active research
             researchComponent.cancelResearch();
             this.audioService.playAudioSprite(AudioSprites.UI_FEEDBACK, UiFeedbackSfx.BUTTON_CLICK);
           } else if (!disabled) {
-            // Start research
+            // Start/queue research
             const success = researchComponent.startResearch(researchType);
             if (success) {
               this.audioService.playAudioSprite(AudioSprites.UI_FEEDBACK, UiFeedbackSfx.BUTTON_CLICK);
@@ -960,7 +973,7 @@ export default class ActorActions extends Phaser.GameObjects.Container {
           }
         },
         tooltipInfo: {
-          title: researchData.name + (isCurrentlyResearching ? " (Click to cancel)" : ""),
+          title: researchData.name + (isActiveInThisBuilding ? " (Click to cancel)" : ""),
           description: researchData.description,
           iconKey: researchData.icon.key,
           iconFrame: researchData.icon.frame,
@@ -974,8 +987,8 @@ export default class ActorActions extends Phaser.GameObjects.Container {
     return index;
   }
 
-  /** Check if any research is currently in progress across all player buildings */
-  private isResearchInProgressGlobally(): boolean {
+  /** Check if a research type is currently queued in any owned building's queue */
+  private isResearchTypeQueuedGlobally(researchType: ResearchType): boolean {
     const playerNr = getCurrentPlayerNumber(this.mainSceneWithActors);
     if (!playerNr) return false;
 
@@ -984,16 +997,19 @@ export default class ActorActions extends Phaser.GameObjects.Container {
 
     const ownedActors = actorIndex.getOwnedActors(playerNr);
 
-    // Check if any owned building is currently researching
     for (const actor of ownedActors) {
-      const researchComponent = getActorComponent(actor, ResearchComponent);
-      if (researchComponent?.isResearching) {
-        return true;
+      const sharedQueue = getActorComponent(actor, QueueComponent);
+      if (sharedQueue) {
+        const hasInQueue = sharedQueue.allItems.some(
+          (item) => item.type === QueueItemType.Research && item.researchData === researchType
+        );
+        if (hasInQueue) return true;
       }
     }
 
     return false;
   }
+
 
   private showBuilderIcons(
     actor: Phaser.GameObjects.GameObject,

--- a/apps/client/src/app/probable-waffle/game/prefabs/gui/labels/ActorInfoLabels.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/gui/labels/ActorInfoLabels.ts
@@ -157,6 +157,9 @@ export default class ActorInfoLabels extends Phaser.GameObjects.Container {
 
       // Initial display
       this.handleQueueUpdate(sharedQueue.items);
+    } else {
+      // Actor has no queue (e.g. a unit) - clear any previously displayed icons
+      this.handleQueueUpdate([]);
     }
   }
 


### PR DESCRIPTION
## Changes
- [x] if you do start a research of a spell, and immediately select an unit, then this spell is showin in units ActorInfoLabels panel
- [x] if you try to move 2 separate researches into queue, 1 gets added, but other ones are removed from ActorActions, so you cannot click on them