### PR TITLE
chore: link tracked TODO comments to GitHub issues

### DIFF
--- a/apps/client/src/app/fly-squasher/game/fly/components/fly-representable-component.ts
+++ b/apps/client/src/app/fly-squasher/game/fly/components/fly-representable-component.ts
@@ -104,7 +104,7 @@ export class FlyRepresentableComponent implements IFlyBase {
       millisecondsSinceKilled
     );
 
-    this._fly.setTint(hexColor.color); // TODO THIS DOESN'T WORK OK
+    this._fly.setTint(hexColor.color); // TODO #646: This doesn't work correctly yet
   }
 
   private displayBlood = () => {

--- a/apps/client/src/app/probable-waffle/game/entity/components/combat/components/health-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/combat/components/health-component.ts
@@ -129,7 +129,7 @@ export class HealthComponent {
             if (this.gameObject.active) asTint.clearTint?.();
           });
         }
-        // TODO SET RUBBLE IN ITS PLACE - use ConstructionGameObjectInterfaceComponent and rename it somehow
+        // TODO #650: Set rubble in its place - use ConstructionGameObjectInterfaceComponent and rename it somehow
         break;
       case ActorPhysicalType.Organic:
         asTint = this.gameObject as any as Phaser.GameObjects.Components.Tint & { clearTint?: () => void };

--- a/apps/client/src/app/probable-waffle/game/entity/systems/spell-casting.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/spell-casting.system.ts
@@ -124,7 +124,7 @@ export class SpellCastingSystem {
 
     // Play cast sound
     if (this.audioService && spellData.sounds?.cast) {
-      // TODO: Play cast sound
+      // TODO #647: Play cast sound
     }
 
     // Spawn projectile or apply effects immediately
@@ -240,12 +240,12 @@ export class SpellCastingSystem {
   ): void {
     // Play impact animation
     if (spellData.projectile?.impactAnimation) {
-      // TODO: Create impact animation at target position
+      // TODO #648: Create impact animation at target position
     }
 
     // Play impact sound
     if (this.audioService && spellData.sounds?.impact) {
-      // TODO: Play impact sound
+      // TODO #649: Play impact sound
     }
 
     // Apply spell effects

--- a/apps/client/src/app/probable-waffle/game/player/ai-controller/player-ai-controller.agent.ts
+++ b/apps/client/src/app/probable-waffle/game/player/ai-controller/player-ai-controller.agent.ts
@@ -850,7 +850,7 @@ export class PlayerAiControllerAgent implements IPlayerControllerAgent {
     return State.SUCCEEDED;
   }
 
-  // TODO we can use something like this to determine if the player is weak (BUT IT NEEDS TO BE EVENT-DRIVEN AND STORED IN THE BLACKBOARD OR PLAYER DIRECTLY)
+  // TODO #654: We can use something like this to determine if the player is weak, but it needs to be event-driven and stored in the blackboard or player directly
   // const { currentPlayerActors, enemyActors } = ScenePlayerHelpers.getActorsByPlayer(this.scene, this.player.playerNumber!);
   // let enemyPlayersUnitsCount = 0;
   // // find enemy player with least units

--- a/apps/client/src/app/probable-waffle/game/prefabs/gui/Minimap.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/gui/Minimap.ts
@@ -106,7 +106,7 @@ export default class Minimap extends Phaser.GameObjects.Container {
     this.redrawMinimap();
     this.probableWaffleScene.events.on(NavigationService.UpdateNavigationEvent, this.throttleRedrawMinimapFrameNonDeterministic, this);
     // Intentional frame update: minimap redraw is HUD rendering and does not mutate authoritative simulation state.
-    this.probableWaffleScene.events.on(Phaser.Scenes.Events.UPDATE, this.throttleRedrawMinimapFrameNonDeterministic, this); // TODO FOR SOME REASON UpdateNavigationEvent doesnt get triggered
+    this.probableWaffleScene.events.on(Phaser.Scenes.Events.UPDATE, this.throttleRedrawMinimapFrameNonDeterministic, this); // TODO #651: For some reason UpdateNavigationEvent doesn't get triggered
   }
 
   private throttleRedrawMinimapFrameNonDeterministic = throttle(this.redrawMinimap.bind(this), 1000);

--- a/apps/client/src/app/probable-waffle/game/prefabs/gui/buttons/ActorAction.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/gui/buttons/ActorAction.ts
@@ -258,7 +258,7 @@ export default class ActorAction extends Phaser.GameObjects.Container {
 
       if (bounds && tooltipBounds) {
         const x = hudScene.scale.width;
-        // TODO - I cannot make it to stick to the top right edge of actor_actions_container - needs further investigation
+        // TODO #653: I cannot make it stick to the top-right edge of actor_actions_container - needs further investigation
         const y = hudScene.scale.height - bounds.height - 80;
         this.tooltip.setPosition(x, y);
       }

--- a/apps/client/src/app/probable-waffle/game/prefabs/gui/labels/ActorDetails.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/gui/labels/ActorDetails.ts
@@ -209,7 +209,7 @@ export default class ActorDetails extends Phaser.GameObjects.Container {
     if (productionTime && productionTime > 0) {
       const timeInSeconds = (productionTime / 1000).toFixed(1);
       iconsAndTexts.push({
-        icon: { key: "gui", frame: "actor_info_icons/training_time.png" }, // TODO: icon doesn't exist yet
+        icon: { key: "gui", frame: "actor_info_icons/training_time.png" }, // TODO #652: icon doesn't exist yet
         text: `${timeInSeconds}s`
       });
     }


### PR DESCRIPTION
## Summary
- add GitHub issue numbers to the tracked TODO comments that were turned into issues
- keep the in-code TODO markers aligned with the created backlog items

## Reasons for Change
- make follow-up work traceable directly from the code
- reduce the chance of TODO context drifting away from GitHub tracking