### PR TITLE
fix: refine chat panel layout for issue 644

### DIFF
--- a/apps/client/src/app/home/chat/chat-float/chat-float.component.scss
+++ b/apps/client/src/app/home/chat/chat-float/chat-float.component.scss
@@ -5,8 +5,9 @@
   bottom: 0;
   right: 0;
   z-index: 999;
-  width: 300px;
-  height: 400px;
+  width: 320px;
+  height: 460px;
+  max-height: 100%;
   overflow: hidden;
 
   .chat {
@@ -21,25 +22,33 @@
       flex-direction: row;
       justify-content: space-between;
       align-items: center;
-      padding: 10px;
+      flex-shrink: 0;
+      padding: 4px 6px;
       color: $app-text-on-dark;
       background-color: $primary;
 
       .chat-title {
         font-family: $app-font-bold;
-        margin-right: 10px;
+        margin-right: 6px;
+        font-size: 0.8rem;
+        line-height: 1;
       }
 
       .chat-minimize {
         display: flex;
         flex-direction: row;
         align-items: center;
-        padding: 10px;
+        justify-content: center;
+        width: 22px;
+        height: 22px;
+        padding: 0;
         border: 1px solid $app-border-ui;
-        border-radius: 10px;
+        border-radius: 6px;
         background-color: $app-surface-plain;
         cursor: pointer;
         color: $dark;
+        font-size: 0.75rem;
+        line-height: 1;
         transition:
           background-color 0.1s ease-in-out,
           color 0.1s ease-in-out;
@@ -56,4 +65,20 @@
 .chat-container-minimized {
   height: unset;
   width: unset;
+
+  .chat {
+    .chat-header {
+      padding: 8px 10px;
+
+      .chat-title {
+        font-size: 1rem;
+      }
+
+      .chat-minimize {
+        width: 30px;
+        height: 30px;
+        font-size: 1rem;
+      }
+    }
+  }
 }

--- a/apps/client/src/app/probable-waffle/gui/in-game-chat/in-game-chat.component.scss
+++ b/apps/client/src/app/probable-waffle/gui/in-game-chat/in-game-chat.component.scss
@@ -4,10 +4,10 @@
   display: flex;
   flex-direction: column;
   height: 100%;
-  min-height: 400px;
-  max-height: 500px;
+  min-height: min(26rem, 100%);
+  max-height: 100%;
   width: 100%;
-  min-width: 350px;
+  min-width: 0;
   background-color: rgba(19, 23, 28, 0.95);
   border-radius: 1rem;
   overflow: hidden;
@@ -15,21 +15,28 @@
 }
 
 fuzzy-waddle-chat {
+  display: flex;
   flex: 1;
   min-height: 0;
+}
+
+fuzzy-waddle-chat ::ng-deep .chat-body {
+  background-color: #fff;
 }
 
 .chat-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 12px 16px;
+  flex-shrink: 0;
+  padding: 5px 8px;
   background-color: rgba(240, 196, 107, 0.12);
   color: #f5ecd9;
 
   .chat-title {
     font-family: "Cinzel", serif;
-    font-size: 18px;
+    font-size: 12px;
+    line-height: 1;
     color: #f0c46b;
   }
 
@@ -37,7 +44,7 @@ fuzzy-waddle-chat {
     background: none;
     border: none;
     color: white;
-    font-size: 24px;
+    font-size: 14px;
     cursor: pointer;
     padding: 0;
     line-height: 1;

--- a/apps/client/src/app/shared/components/chat/chat.component.html
+++ b/apps/client/src/app/shared/components/chat/chat.component.html
@@ -10,17 +10,19 @@
             <div class="chat-message-header">
               <div class="chat-message-sender">
                 <img alt="avatar" class="avatar" height="20" src="{{ avatarProviderService.getAvatar(message.userId) }}" />
-                <button class="chat-message-sender-name" type="button" (click)="openProfile(message)">{{ message.fullName }}</button>
-                @if (getRoleIcon(message.senderRole ?? null); as roleIcon) {
-                  <fa-icon
-                    [icon]="roleIcon"
-                    [title]="getRoleLabel(message.senderRole ?? null) ?? ''"
-                    class="chat-message-role-icon"
-                  />
-                }
-                @if (message.reportedByCurrentUser) {
-                  <span class="chat-message-reported-label">Reported</span>
-                }
+                <div class="chat-message-sender-meta">
+                  <button class="chat-message-sender-name" type="button" (click)="openProfile(message)">{{ message.fullName }}</button>
+                  @if (getRoleIcon(message.senderRole ?? null); as roleIcon) {
+                    <fa-icon
+                      [icon]="roleIcon"
+                      [title]="getRoleLabel(message.senderRole ?? null) ?? ''"
+                      class="chat-message-role-icon"
+                    />
+                  }
+                  @if (message.reportedByCurrentUser) {
+                    <span class="chat-message-reported-label">Reported</span>
+                  }
+                </div>
               </div>
               <div class="chat-message-menu">
                 <button class="chat-message-menu-button" type="button" (click)="toggleMessageMenu(message)">
@@ -43,17 +45,19 @@
             <div class="chat-message-header">
               <div class="chat-message-sender">
                 <img alt="avatar" class="avatar" height="20" src="{{ avatarProviderService.getAvatar(message.userId) }}" />
-                <button class="chat-message-sender-name" type="button" (click)="openProfile(message)">{{ message.fullName }}</button>
-                @if (getRoleIcon(message.senderRole ?? null); as roleIcon) {
-                  <fa-icon
-                    [icon]="roleIcon"
-                    [title]="getRoleLabel(message.senderRole ?? null) ?? ''"
-                    class="chat-message-role-icon"
-                  />
-                }
-                @if (message.reportedByCurrentUser) {
-                  <span class="chat-message-reported-label">Reported</span>
-                }
+                <div class="chat-message-sender-meta">
+                  <button class="chat-message-sender-name" type="button" (click)="openProfile(message)">{{ message.fullName }}</button>
+                  @if (getRoleIcon(message.senderRole ?? null); as roleIcon) {
+                    <fa-icon
+                      [icon]="roleIcon"
+                      [title]="getRoleLabel(message.senderRole ?? null) ?? ''"
+                      class="chat-message-role-icon"
+                    />
+                  }
+                  @if (message.reportedByCurrentUser) {
+                    <span class="chat-message-reported-label">Reported</span>
+                  }
+                </div>
               </div>
             </div>
           }

--- a/apps/client/src/app/shared/components/chat/chat.component.scss
+++ b/apps/client/src/app/shared/components/chat/chat.component.scss
@@ -1,12 +1,16 @@
 @use "../../../../styles/_variables" as *;
 
+:host {
+  min-height: 0;
+}
+
 .chat-body {
   display: flex;
   flex-direction: column;
-  flex-grow: 1;
-  height: 0;
+  flex: 1 1 auto;
+  min-height: 0;
   overflow: auto;
-  padding: 10px;
+  padding: 8px;
 
   .chat-messages {
     display: flex;
@@ -32,52 +36,76 @@
           align-items: flex-start;
           justify-content: space-between;
           gap: 8px;
+          min-width: 0;
         }
 
         .chat-message-sender {
           font-family: $app-font-bold;
           display: flex;
-          align-items: center;
-          flex-wrap: wrap;
+          align-items: flex-start;
+          flex: 1;
+          min-width: 0;
 
-          .chat-message-sender-name {
+          .chat-message-sender-meta {
+            display: flex;
+            align-items: center;
+            flex: 1;
+            flex-wrap: wrap;
+            min-width: 0;
             margin-left: 5px;
-            margin-right: 5px;
-            padding: 0;
-            border: 0;
-            background: transparent;
-            color: inherit;
-            cursor: pointer;
-            text-decoration: underline;
-            text-underline-offset: 2px;
 
-            &:hover {
-              color: $primary;
+            .chat-message-sender-name {
+              display: inline-block;
+              min-width: 0;
+              max-width: 100%;
+              margin-right: 5px;
+              padding: 0;
+              border: 0;
+              background: transparent;
+              color: inherit;
+              cursor: pointer;
+              font-size: 0.9rem;
+              line-height: 1.2;
+              text-align: left;
+              text-decoration: underline;
+              text-underline-offset: 2px;
+              overflow-wrap: anywhere;
+              word-break: break-word;
+              white-space: normal;
+
+              &:hover {
+                color: $primary;
+              }
             }
-          }
 
-          .chat-message-role-icon {
-            color: $primary;
-            margin-right: 5px;
-          }
+            .chat-message-role-icon {
+              color: $primary;
+              margin-right: 5px;
+            }
 
-          .chat-message-reported-label {
-            border: 1px solid $primary;
-            border-radius: 4px;
-            font-family: sans-serif;
-            font-size: 0.7rem;
-            padding: 0 4px;
+            .chat-message-reported-label {
+              border: 1px solid $primary;
+              border-radius: 4px;
+              font-family: sans-serif;
+              font-size: 0.7rem;
+              padding: 0 4px;
+            }
           }
         }
 
         .chat-message-text {
-          margin-top: 2px;
+          margin-top: 1px;
           margin-bottom: 2px;
+          font-size: 0.95rem;
+          line-height: 1.25;
+          overflow-wrap: anywhere;
+          word-break: break-word;
         }
 
         .chat-message-menu {
           position: relative;
           margin-left: auto;
+          flex-shrink: 0;
 
           .chat-message-menu-button {
             border: 0;
@@ -166,26 +194,31 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  padding: 10px;
+  flex-shrink: 0;
+  gap: 6px;
+  padding: 6px 8px 8px;
   border-top: 2px solid $primary;
   background-color: $quaternary;
 
   .chat-report-status {
-    margin-bottom: 8px;
-    font-size: 0.8rem;
+    margin-bottom: 0;
+    font-size: 0.75rem;
   }
 
   .chat-form {
     display: flex;
     flex-direction: row;
-    align-items: center;
+    align-items: stretch;
+    gap: 6px;
     width: 100%;
 
     .chat-input {
-      margin-right: 10px;
+      min-width: 0;
       width: 100%;
-      padding: 10px;
-      border-radius: 10px;
+      padding: 7px 9px;
+      border-radius: 8px;
+      font-size: 0.9rem;
+      line-height: 1.2;
       outline: none;
       border: 2px solid $primary;
       background-color: $app-surface-plain;
@@ -195,11 +228,16 @@
       display: flex;
       flex-direction: row;
       align-items: center;
-      padding: 10px;
+      justify-content: center;
+      flex-shrink: 0;
+      min-width: 64px;
+      padding: 7px 10px;
       border: 1px solid $app-border-ui;
-      border-radius: 10px;
+      border-radius: 8px;
       background-color: $app-surface-plain;
       cursor: pointer;
+      font-size: 0.85rem;
+      line-height: 1.1;
       transition:
         background-color 0.1s ease-in-out,
         color 0.1s ease-in-out;


### PR DESCRIPTION
## Summary
- wrap long sender names and keep role badges aligned beside them
- compact shared and standalone chat controls while preserving scrollable message space
- tune in-game chat sizing and set its message body background to white

## Reasons for Change
- prevent horizontal overflow from long names and unbroken chat content
- free more vertical room for messages without exceeding the parent height