### PR TITLE
fix: handle multiplayer quit score flow

### DIFF
--- a/apps/api/src/app/probable-waffle/game-instance/multiplayer/player-state-validator.service.ts
+++ b/apps/api/src/app/probable-waffle/game-instance/multiplayer/player-state-validator.service.ts
@@ -43,11 +43,13 @@ export class PlayerStateValidatorService {
     ProbableWafflePlayerDataChangeProperties.SelectionCleared
   ]);
   private static readonly CONTROL_GROUP_PROPERTY = ProbableWafflePlayerDataChangeProperties.SelectionGroupsChanged;
+  private static readonly LEFT_OR_KILLED_PROPERTY = ProbableWafflePlayerDataChangeProperties.LeftOrKilledChanged;
   private static readonly OWNER_ONLY_PROPERTIES: ReadonlySet<PlayerDataChangeProperty> = new Set([
     ...PlayerStateValidatorService.RESOURCE_PROPERTIES,
     ...PlayerStateValidatorService.HOUSING_PROPERTIES,
     ...PlayerStateValidatorService.SELECTION_PROPERTIES,
     PlayerStateValidatorService.CONTROL_GROUP_PROPERTY,
+    PlayerStateValidatorService.LEFT_OR_KILLED_PROPERTY,
     ProbableWafflePlayerDataChangeProperties.PlayerSceneReady,
     ProbableWafflePlayerDataChangeProperties.CommandIssuedMove,
     ProbableWafflePlayerDataChangeProperties.CommandIssuedActor
@@ -88,6 +90,8 @@ export class PlayerStateValidatorService {
       case ProbableWafflePlayerDataChangeProperties.SelectionSet:
       case ProbableWafflePlayerDataChangeProperties.SelectionCleared:
         return this.validateSelectionChange(event, gameInstance);
+      case PlayerStateValidatorService.LEFT_OR_KILLED_PROPERTY:
+        return this.validateLeftOrKilledChange(event);
       case PlayerStateValidatorService.CONTROL_GROUP_PROPERTY:
         return this.validateSelectionGroupsChange(event, gameInstance);
       default:
@@ -173,6 +177,16 @@ export class PlayerStateValidatorService {
         );
         return false;
       }
+    }
+
+    return true;
+  }
+
+  private validateLeftOrKilledChange(event: ProbableWafflePlayerDataChangeEvent): boolean {
+    const leftOrKilled = event.data.playerControllerData?.leftOrKilled;
+    if (typeof leftOrKilled !== "boolean") {
+      this.logger.warn(`[PlayerState] Invalid leftOrKilled payload in ${event.gameInstanceId}`);
+      return false;
     }
 
     return true;

--- a/apps/api/src/app/probable-waffle/game-instance/multiplayer/player-state-validator.service.ts
+++ b/apps/api/src/app/probable-waffle/game-instance/multiplayer/player-state-validator.service.ts
@@ -183,6 +183,8 @@ export class PlayerStateValidatorService {
   }
 
   private validateLeftOrKilledChange(event: ProbableWafflePlayerDataChangeEvent): boolean {
+    // Quit/elimination is intentionally simple here: ownership is enforced by
+    // OWNER_ONLY_PROPERTIES and the payload itself is just a boolean flag.
     const leftOrKilled = event.data.playerControllerData?.leftOrKilled;
     if (typeof leftOrKilled !== "boolean") {
       this.logger.warn(`[PlayerState] Invalid leftOrKilled payload in ${event.gameInstanceId}`);

--- a/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.interface.ts
+++ b/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.interface.ts
@@ -53,4 +53,5 @@ export interface GameInstanceClientServiceInterface {
   saveGameInstance(data: Record<string, any>): Promise<void>;
   startReplay(gameInstanceSaveData: ProbableWaffleGameInstanceSaveData): Promise<void>;
   leaveLobby(): Promise<void>;
+  leaveScoreScreen(navigateHome?: boolean): Promise<void>;
 }

--- a/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.stub.ts
+++ b/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.stub.ts
@@ -128,5 +128,8 @@ export const gameInstanceClientServiceStub = {
   },
   async leaveLobby(): Promise<void> {
     return Promise.resolve();
+  },
+  async leaveScoreScreen(navigateHome: boolean = true): Promise<void> {
+    return Promise.resolve();
   }
 } satisfies GameInstanceClientServiceInterface;

--- a/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.ts
+++ b/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.ts
@@ -738,6 +738,9 @@ export class GameInstanceClientService implements GameInstanceClientServiceInter
   }
 
   async leaveScoreScreen(navigateHome: boolean = true): Promise<void> {
+    // Leaving results means this player is done consuming the finished match.
+    // The server's existing player.left handling tears the instance down only
+    // after the last human has left, so avoid sending global Stopped here.
     await this.disconnectSelfFromCurrentGame();
     await this.cleanupLocalGameState();
 

--- a/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.ts
+++ b/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.ts
@@ -737,6 +737,15 @@ export class GameInstanceClientService implements GameInstanceClientServiceInter
     await this.router.navigate(["aota"]);
   }
 
+  async leaveScoreScreen(navigateHome: boolean = true): Promise<void> {
+    await this.disconnectSelfFromCurrentGame();
+    await this.cleanupLocalGameState();
+
+    if (navigateHome) {
+      await this.router.navigate(["aota"]);
+    }
+  }
+
   private async cleanupLocalGameState(): Promise<void> {
     await this.stopListeningToGameInstanceEvents();
     this.gameInstance = undefined;

--- a/apps/client/src/app/probable-waffle/game/world/state/GameModeConditionChecker.ts
+++ b/apps/client/src/app/probable-waffle/game/world/state/GameModeConditionChecker.ts
@@ -144,6 +144,9 @@ export class GameModeConditionChecker {
           return;
         }
 
+        // Remote quits do not always line up with this checker's periodic tick.
+        // Re-evaluate immediately so the surviving player can resolve victory
+        // without waiting for another scheduled pass.
         if (this.checkWinConditions()) {
           this.winGame();
         }
@@ -370,6 +373,8 @@ export class GameModeConditionChecker {
       scoreTracker.stop();
     }
 
+    // Quit is a per-player exit. Route only this client to the score screen and
+    // let the remaining players finish through the normal shared win/loss flow.
     this.navigateToScoreScreenLocally();
     this.stop();
   }
@@ -477,6 +482,8 @@ export class GameModeConditionChecker {
   private broadcastScoreScreenTransition() {
     const baseGameData = getBaseGameDataFromScene<ProbableWaffleGameData>(this.scene);
     const communicator = baseGameData.communicator;
+    // Win/loss/tie are match-wide outcomes, so this session-state transition
+    // must be broadcast to every client that is still attached to the match.
     communicator.gameInstanceMetadataChanged?.send({
       property: "sessionState",
       gameInstanceId: baseGameData.gameInstance.gameInstanceMetadata.data.gameInstanceId!,
@@ -488,6 +495,8 @@ export class GameModeConditionChecker {
   private navigateToScoreScreenLocally() {
     const baseGameData = getBaseGameDataFromScene<ProbableWaffleGameData>(this.scene);
     const communicator = baseGameData.communicator;
+    // Local-only quit redirect: peers should keep simulating until their own
+    // global end condition resolves and broadcasts the match-wide transition.
     communicator.gameInstanceMetadataChanged?.sendLocally({
       property: "sessionState",
       gameInstanceId: baseGameData.gameInstance.gameInstanceMetadata.data.gameInstanceId!,

--- a/apps/client/src/app/probable-waffle/game/world/state/GameModeConditionChecker.ts
+++ b/apps/client/src/app/probable-waffle/game/world/state/GameModeConditionChecker.ts
@@ -8,6 +8,7 @@ import {
   GameResultStatus,
   GameSessionState,
   type LoseConditions,
+  ProbableWafflePlayerDataChangeProperties,
   ProbableWaffleGameInstanceType,
   ProbableWaffleGameMode,
   ProbableWafflePlayer,
@@ -41,6 +42,7 @@ export class GameModeConditionChecker {
   private players!: ProbableWafflePlayer[];
   private currentPlayer!: ProbableWafflePlayer;
   private selfQuitSubscription?: Subscription;
+  private playerLeftOrKilledSubscription?: Subscription;
   private stopped: boolean = false;
   private readonly checkIntervalTicks = 20; // 1 second at the fixed 20 Hz simulation rate.
   private readonly surrenderCheckIntervalTicks = 40; // 2 seconds at the fixed 20 Hz simulation rate.
@@ -57,6 +59,7 @@ export class GameModeConditionChecker {
     this.currentDelay = new CancelableSimDelay(this.scene, 1000, () => this.startChecking());
     this.scene.events.once(Phaser.Scenes.Events.SHUTDOWN, this.destroy, this);
     this.listenToPlayerQuit();
+    this.listenToPlayerLeftOrKilled();
   }
 
   private startChecking() {
@@ -122,10 +125,29 @@ export class GameModeConditionChecker {
       // check if player has no actors left, if yes, mark as left or killed
       const actors = this.actorsByPlayer?.get(player.playerNumber!) || [];
       if (actors.length === 0) {
-        player.playerController.data.leftOrKilled = true;
+        this.markPlayerLeftOrKilled(player);
         console.log(`Player ${player.playerNumber} has no actors left, marked as killed.`);
       }
     });
+  }
+
+  private listenToPlayerLeftOrKilled() {
+    this.playerLeftOrKilledSubscription = this.scene.communicator.playerChanged?.on
+      .pipe(filter((event) => event.property === ProbableWafflePlayerDataChangeProperties.LeftOrKilledChanged))
+      .subscribe((event) => {
+        if (this.stopped || !isSceneActive(this.scene)) {
+          return;
+        }
+
+        this.ensureCurrentPlayerPrepared();
+        if (event.data.playerNumber === this.currentPlayerNumber) {
+          return;
+        }
+
+        if (this.checkWinConditions()) {
+          this.winGame();
+        }
+      });
   }
 
   private checkAiSurrender(tick: number) {
@@ -206,7 +228,7 @@ export class GameModeConditionChecker {
   private handleSurrenderAccepted(player: ProbableWafflePlayer) {
     console.log(`Player ${player.playerNumber} surrender accepted - eliminating player`);
     // Mark player as eliminated
-    player.playerController.data.leftOrKilled = true;
+    this.markPlayerLeftOrKilled(player);
 
     // Destroy all units/buildings owned by this player
     const actors = this.actorsByPlayer?.get(player.playerNumber!) || [];
@@ -312,7 +334,7 @@ export class GameModeConditionChecker {
       const buildings = actors.filter((actor) => getActorComponent(actor, ConstructionSiteComponent));
       if (buildings.length === 0) {
         console.log("All buildings eliminated, lose condition met.");
-        this.currentPlayer.playerController.data.leftOrKilled = true;
+        this.markPlayerLeftOrKilled(this.currentPlayer);
         return true; // No buildings left, consider it a loss
       }
     }
@@ -336,7 +358,8 @@ export class GameModeConditionChecker {
   }
 
   private selfQuit() {
-    this.currentPlayer.playerController.data.leftOrKilled = true;
+    this.ensureCurrentPlayerPrepared();
+    this.markPlayerLeftOrKilled(this.currentPlayer);
     console.log(`Player ${this.currentPlayer.playerNumber} has quit the game.`);
 
     // Update ScoreTracker
@@ -347,8 +370,44 @@ export class GameModeConditionChecker {
       scoreTracker.stop();
     }
 
-    this.navigateToScoreScreen();
+    this.navigateToScoreScreenLocally();
     this.stop();
+  }
+
+  /**
+   * leftOrKilled is shared match state. When a player quits or is eliminated we
+   * must relay it, otherwise other clients keep evaluating stale opponents and
+   * never resolve the remaining player's win condition.
+   */
+  private markPlayerLeftOrKilled(player: ProbableWafflePlayer) {
+    if (player.playerController.data.leftOrKilled) {
+      return;
+    }
+
+    player.playerController.data.leftOrKilled = true;
+    if (player.playerNumber === undefined) {
+      return;
+    }
+
+    this.scene.communicator.playerChanged?.send({
+      property: ProbableWafflePlayerDataChangeProperties.LeftOrKilledChanged,
+      gameInstanceId: this.scene.gameInstanceId,
+      emitterUserId: this.scene.userId,
+      data: {
+        playerNumber: player.playerNumber,
+        playerControllerData: {
+          leftOrKilled: true
+        }
+      }
+    });
+  }
+
+  private ensureCurrentPlayerPrepared() {
+    if (this.currentPlayer && this.currentPlayerNumber !== undefined) {
+      return;
+    }
+
+    this.prepareData();
   }
 
   private winGame() {
@@ -369,7 +428,7 @@ export class GameModeConditionChecker {
     }
 
     this.createEndGameLayer("You have won the game!", () => {
-      this.navigateToScoreScreen();
+      this.broadcastScoreScreenTransition();
     });
     this.stop();
   }
@@ -392,7 +451,7 @@ export class GameModeConditionChecker {
     }
 
     this.createEndGameLayer("You have lost the game.", () => {
-      this.navigateToScoreScreen();
+      this.broadcastScoreScreenTransition();
     });
     this.stop();
   }
@@ -410,16 +469,26 @@ export class GameModeConditionChecker {
     }
 
     this.createEndGameLayer("The game ended in a tie!", () => {
-      this.navigateToScoreScreen();
+      this.broadcastScoreScreenTransition();
     });
     this.stop();
   }
 
-  private navigateToScoreScreen() {
+  private broadcastScoreScreenTransition() {
     const baseGameData = getBaseGameDataFromScene<ProbableWaffleGameData>(this.scene);
     const communicator = baseGameData.communicator;
-    // todo rather than this, change the player state session state to "to score screen" because only 1 player quits
     communicator.gameInstanceMetadataChanged?.send({
+      property: "sessionState",
+      gameInstanceId: baseGameData.gameInstance.gameInstanceMetadata.data.gameInstanceId!,
+      data: { sessionState: GameSessionState.ToScoreScreen },
+      emitterUserId: baseGameData.user.userId
+    });
+  }
+
+  private navigateToScoreScreenLocally() {
+    const baseGameData = getBaseGameDataFromScene<ProbableWaffleGameData>(this.scene);
+    const communicator = baseGameData.communicator;
+    communicator.gameInstanceMetadataChanged?.sendLocally({
       property: "sessionState",
       gameInstanceId: baseGameData.gameInstance.gameInstanceMetadata.data.gameInstanceId!,
       data: { sessionState: GameSessionState.ToScoreScreen },
@@ -443,6 +512,7 @@ export class GameModeConditionChecker {
     this.simulationTickSub?.unsubscribe();
     this.scene.events.off(Phaser.Scenes.Events.SHUTDOWN, this.destroy, this);
     this.selfQuitSubscription?.unsubscribe();
+    this.playerLeftOrKilledSubscription?.unsubscribe();
     this.currentDelay?.remove();
   }
 }

--- a/apps/client/src/app/probable-waffle/gui/score-screen/score-screen.component.html
+++ b/apps/client/src/app/probable-waffle/gui/score-screen/score-screen.component.html
@@ -21,7 +21,7 @@
     }
 
     <div class="mt-4">
-      <button class="btn btn-primary" routerLink="/aota">Leave</button>
+      <button class="btn btn-primary" (click)="leave()">Leave</button>
     </div>
   </div>
 </div>

--- a/apps/client/src/app/probable-waffle/gui/score-screen/score-screen.component.ts
+++ b/apps/client/src/app/probable-waffle/gui/score-screen/score-screen.component.ts
@@ -94,6 +94,8 @@ export class ScoreScreenComponent implements OnInit, OnDestroy {
 
   @HostListener("window:beforeunload")
   async onBeforeUnload() {
+    // Best-effort score-screen exit. This should remove only the current player
+    // from the finished match, not force-stop the session for other viewers.
     await this.gameInstanceClientService.leaveScoreScreen(false);
   }
 

--- a/apps/client/src/app/probable-waffle/gui/score-screen/score-screen.component.ts
+++ b/apps/client/src/app/probable-waffle/gui/score-screen/score-screen.component.ts
@@ -26,6 +26,10 @@ export class ScoreScreenComponent implements OnInit, OnDestroy {
     this.activeTab = scoreTable;
   };
 
+  protected leave = async () => {
+    await this.gameInstanceClientService.leaveScoreScreen();
+  };
+
   async ngOnInit() {
     // Submit scores if this is an online game and user is last human player
     const gameInstance = this.gameInstanceClientService.gameInstance;
@@ -90,11 +94,10 @@ export class ScoreScreenComponent implements OnInit, OnDestroy {
 
   @HostListener("window:beforeunload")
   async onBeforeUnload() {
-    await this.ngOnDestroy();
+    await this.gameInstanceClientService.leaveScoreScreen(false);
   }
 
   async ngOnDestroy() {
     this.scoreSubmissionSub?.unsubscribe();
-    await this.gameInstanceClientService.stopGameInstance();
   }
 }

--- a/libs/api-interfaces/src/lib/communicators/probable-waffle/communicators.ts
+++ b/libs/api-interfaces/src/lib/communicators/probable-waffle/communicators.ts
@@ -80,6 +80,7 @@ export const ProbableWafflePlayerDataChangeProperties = {
   Joined: "joined",
   Left: "left",
   JoinedFromNetwork: "joinedFromNetwork",
+  LeftOrKilledChanged: "playerController.data.leftOrKilled",
   SelectionAdded: "selection.added",
   SelectionRemoved: "selection.removed",
   SelectionSet: "selection.set",
@@ -109,6 +110,7 @@ export type ProbableWafflePlayerDataChangeEventProperty =
   | typeof ProbableWafflePlayerDataChangeProperties.Joined
   | typeof ProbableWafflePlayerDataChangeProperties.Left
   | typeof ProbableWafflePlayerDataChangeProperties.JoinedFromNetwork
+  | typeof ProbableWafflePlayerDataChangeProperties.LeftOrKilledChanged
   | typeof ProbableWafflePlayerDataChangeProperties.SelectionAdded
   | typeof ProbableWafflePlayerDataChangeProperties.SelectionRemoved
   | typeof ProbableWafflePlayerDataChangeProperties.SelectionSet

--- a/libs/api-interfaces/src/lib/communicators/probable-waffle/listeners.ts
+++ b/libs/api-interfaces/src/lib/communicators/probable-waffle/listeners.ts
@@ -169,6 +169,12 @@ export class ProbableWaffleListeners {
           player.playerController.data.selectionGroups = payload.data.playerControllerData!.selectionGroups;
           ProbableWaffleListeners.logDebugInfo("selection groups changed for player", player.playerNumber);
           break;
+        case "playerController.data.leftOrKilled" as ProbableWafflePlayerDataChangeEventProperty:
+          player = gameInstance.getPlayerByNumber(payload.data.playerNumber!);
+          if (!player) throw new Error("Player not found with number " + payload.data.playerNumber);
+          player.playerController.data.leftOrKilled = payload.data.playerControllerData!.leftOrKilled;
+          ProbableWaffleListeners.logDebugInfo("leftOrKilled changed for player", player.playerNumber);
+          break;
 
         case "selection.added" as ProbableWafflePlayerDataChangeEventProperty:
           player = gameInstance.getPlayerByNumber(payload.data.playerNumber!);

--- a/libs/api-interfaces/src/lib/game-instance/session.ts
+++ b/libs/api-interfaces/src/lib/game-instance/session.ts
@@ -1,8 +1,52 @@
+/**
+ * Shared lifecycle states for one game session.
+ *
+ * These states are broadcast through `gameInstanceMetadata.sessionState` and are
+ * consumed by both Angular routing and Phaser scene/HUD state handlers.
+ */
 export enum GameSessionState {
+  /**
+   * Lobby/setup phase before the match has been launched.
+   * Triggered when a game instance is created or returned to an unstarted state.
+   */
   NotStarted,
+  /**
+   * The host has started the match and clients should move from lobby UI into
+   * the game scenes. World scenes pause here until every human player is ready.
+   */
   MovingPlayersToGame,
+  /**
+   * The ready barrier has opened and the match is about to begin.
+   * In multiplayer this is the short synchronized countdown window before
+   * simulation resumes; in local modes it can advance immediately.
+   */
   StartingTheGame,
+  /**
+   * Active gameplay.
+   * Triggered after the start countdown completes and the simulation is allowed
+   * to run normally.
+   */
   InProgress,
+  /**
+   * Match-complete score-screen transition.
+   * Triggered only when the match has resolved for every remaining participant.
+   *
+   * Typical examples:
+   * - the last surviving player hits a win condition, so all opponents are
+   *   resolved as losses and the whole session moves to score screen
+   * - the current player hits a lose condition and the remaining active
+   *   opponents are resolved as winners
+   * - a tie condition ends the match for everyone at once
+   *
+   * Important: a single player quitting should not broadcast this state for the
+   * whole match. Quit uses a local-only redirect for that player while the
+   * remaining players continue until one of the global match-end outcomes above
+   * is reached.
+   */
   ToScoreScreen,
+  /**
+   * Terminal cleanup state after a match instance is being torn down.
+   * Triggered when the session is explicitly stopped or no human players remain.
+   */
   Stopped
 }


### PR DESCRIPTION
## Summary
- sync quit and elimination through shared `leftOrKilled` player state
- send the quitting player to score screen locally while letting the remaining player resolve victory normally
- stop tearing down the whole match from score-screen component destruction or route re-entry
- stop the game instance only after players actually leave the score screen

## Reasons for Change
- quitting one player was leaving the other client in a stale match state or stopping the session before score-screen routing completed

## Notes
- added `GameSessionState` docs to clarify global score-screen transitions versus local quit flow