### PR TITLE
Implement actor rally points

### DIFF
--- a/apps/client/src/app/probable-waffle/game/entity/components/owner-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/owner-component.ts
@@ -19,6 +19,7 @@ import { SceneLightingService } from "../../world/services/lighting/scene-lighti
 export class OwnerComponent {
   static readonly ZIndex = 1;
   static readonly OwnerColorAppliedEvent = "owner-color-applied";
+  static readonly OwnerChangedEvent = "owner-changed";
   private readonly borderSize = 2;
   /**
    * Not using color replace as it adds huge load on GPU
@@ -85,6 +86,7 @@ export class OwnerComponent {
     actorIndexSystem?.updateActorOwnership(this.gameObject, oldOwner, newOwner);
     this.owner = playerNumber;
     this.tryToSetComponents();
+    this.gameObject.emit(OwnerComponent.OwnerChangedEvent, oldOwner, newOwner);
   }
 
   setOwnerWithBlink(playerNumber: PlayerNumber) {

--- a/apps/client/src/app/probable-waffle/game/entity/components/production/production-component.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/components/production/production-component.ts
@@ -29,6 +29,10 @@ import { MovementTerrainType } from "../movement/movement-terrain-type";
 import { ProbableWaffleSceneEventName } from "../../../world/services/recovery/probable-waffle-scene-events";
 import { CommandBusService } from "../../../world/services/multiplayer/command-bus.service";
 import { IdComponent } from "../id-component";
+import { OrderType } from "../../../ai/order-type";
+import { ActorIndexSystem } from "../../../world/services/ActorIndexSystem";
+import { getActorSystem } from "../../../data/actor-system";
+import { ActionSystem } from "../../systems/action.system";
 import GameObject = Phaser.GameObjects.GameObject;
 
 export class ProductionComponent {
@@ -46,6 +50,7 @@ export class ProductionComponent {
     this.rallyPoint = new RallyPoint(this.gameObject.scene);
     this.listenToMoveEvents();
     onObjectReady(gameObject, this.initOnObjectReady, this);
+    gameObject.on(OwnerComponent.OwnerChangedEvent, this.handleOwnerChanged, this);
     gameObject.on(Phaser.GameObjects.Events.DESTROY, this.destroy, this);
     gameObject.once(HealthComponent.KilledEvent, this.destroy, this);
   }
@@ -81,10 +86,6 @@ export class ProductionComponent {
     }
 
     this.playerChangedSubscription = commandBus.command$.subscribe((command) => {
-      if (command.type !== ProbableWaffleGameCommandTypes.Move) {
-        return;
-      }
-
       const owner = getActorComponent(this.gameObject, OwnerComponent)?.getOwner();
       if (owner === undefined || owner !== command.playerNumber) {
         return;
@@ -95,10 +96,40 @@ export class ProductionComponent {
         return;
       }
 
-      // Rally-point assignment is a deterministic MOVE command targeting production buildings.
-      // Apply it on every client from the command bus stream, not local UI events.
-      this.rallyPoint.setLocation(command.tileVec3, command.worldVec3);
+      if (command.type === ProbableWaffleGameCommandTypes.Move) {
+        // Rally-point assignment is a deterministic MOVE command targeting production buildings.
+        // Apply it on every client from the command bus stream, not local UI events.
+        this.rallyPoint.setLocation(command.tileVec3, command.worldVec3);
+        return;
+      }
+
+      if (command.type !== ProbableWaffleGameCommandTypes.ActorAction) {
+        return;
+      }
+
+      if (command.orderType !== undefined && command.orderType !== OrderType.Move) {
+        return;
+      }
+
+      const targetActorId = command.targetObjectIds?.[0];
+      if (!targetActorId) {
+        this.rallyPoint.reset();
+        return;
+      }
+
+      const actorIndex = getSceneService(this.gameObject.scene, ActorIndexSystem);
+      const targetActor = actorIndex?.getActorById(targetActorId);
+      if (!targetActor) {
+        this.rallyPoint.reset();
+        return;
+      }
+
+      this.rallyPoint.setActor(targetActor as Phaser.GameObjects.GameObject & Phaser.GameObjects.Components.Transform);
     });
+  }
+
+  private handleOwnerChanged() {
+    this.rallyPoint.reset();
   }
 
   get isProducing(): boolean {
@@ -226,7 +257,7 @@ export class ProductionComponent {
     // Determine target tile preference based on rally point if it's set
     let targetTile: Vector3Simple | undefined;
     if (this.rallyPoint.isSet()) {
-      targetTile = this.rallyPoint.tileVec3;
+      targetTile = this.rallyPoint.getTargetTileVec3();
     }
 
     const unitDef = getPwActorDefinition(actorName, null);
@@ -273,9 +304,28 @@ export class ProductionComponent {
         this.gameObject.scene.events.emit(ProbableWaffleSceneEventName.ScoreUnitProduced, originalOwner);
       }
       if (this.rallyPoint.isSet()) {
-        // noinspection JSIgnoredPromiseFromCall
-        this.rallyPoint.navigateGameObjectToRallyPoint(newGameObject);
+        this.executeSpawnRallyAction(newGameObject);
       }
+    }
+  }
+
+  private executeSpawnRallyAction(newGameObject: Phaser.GameObjects.GameObject) {
+    const actionSystem = getActorSystem<ActionSystem>(newGameObject, ActionSystem);
+    if (!actionSystem) {
+      // noinspection JSIgnoredPromiseFromCall
+      this.rallyPoint.navigateGameObjectToRallyPoint(newGameObject);
+      return;
+    }
+
+    const targetGameObject = this.rallyPoint.getTargetGameObject();
+    if (targetGameObject?.active) {
+      actionSystem.executeAction(undefined, targetGameObject);
+      return;
+    }
+
+    const targetTile = this.rallyPoint.getTargetTileVec3();
+    if (targetTile) {
+      actionSystem.executeAction(OrderType.Move, undefined, targetTile);
     }
   }
 
@@ -357,6 +407,7 @@ export class ProductionComponent {
 
   private destroy() {
     this.playerChangedSubscription?.unsubscribe();
+    this.gameObject.off(OwnerComponent.OwnerChangedEvent, this.handleOwnerChanged, this);
     this.rallyPoint.destroy();
   }
 

--- a/apps/client/src/app/probable-waffle/game/entity/systems/action.system.ts
+++ b/apps/client/src/app/probable-waffle/game/entity/systems/action.system.ts
@@ -74,10 +74,6 @@ export class ActionSystem {
   }
 
   private handleActorActionCommand(cmd: ActorActionCommand) {
-    const payerPawnAiController = getActorComponent(this.gameObject, PawnAiController);
-    if (!payerPawnAiController) return;
-
-    let action: OrderData | null = null;
     let targetGameObject: Phaser.GameObjects.GameObject | undefined;
 
     if (cmd.targetObjectIds) {
@@ -89,31 +85,46 @@ export class ActionSystem {
       }
     }
 
-    if (cmd.orderType) {
-      action = new OrderData(cmd.orderType, {
+    this.executeAction(cmd.orderType, targetGameObject, cmd.tileVec3, cmd.queue);
+  }
+
+  public executeAction(
+    orderType?: OrderType,
+    targetGameObject?: Phaser.GameObjects.GameObject,
+    tileVec3?: ActorActionCommand["tileVec3"],
+    queue: boolean = false
+  ): boolean {
+    const payerPawnAiController = getActorComponent(this.gameObject, PawnAiController);
+    if (!payerPawnAiController) return false;
+
+    let action: OrderData | null = null;
+
+    if (orderType) {
+      action = new OrderData(orderType, {
         targetGameObject,
-        targetTileLocation: cmd.tileVec3
+        targetTileLocation: tileVec3
       });
     } else if (targetGameObject) {
       action = this.findAction(targetGameObject);
-    } else if (cmd.tileVec3) {
+    } else if (tileVec3) {
       action = new OrderData(OrderType.Move, {
-        targetTileLocation: cmd.tileVec3
+        targetTileLocation: tileVec3
       });
     }
 
-    if (!action) return;
+    if (!action) return false;
 
     if (this.displayDebugInfo && !environment.production) {
       console.log("ActionSystem: action", action);
     }
 
-    if (cmd.queue) {
+    if (queue) {
       payerPawnAiController.blackboard.addOrder(action);
     } else {
       payerPawnAiController.blackboard.overrideOrderQueueAndActiveOrder(action);
     }
     this.playOrderSound(action);
+    return true;
   }
 
   private handleStopCommand() {

--- a/apps/client/src/app/probable-waffle/game/prefabs/buildings/misc/RallyPoint.ts
+++ b/apps/client/src/app/probable-waffle/game/prefabs/buildings/misc/RallyPoint.ts
@@ -12,12 +12,20 @@ import { GameObjects } from "phaser";
 import { getActorComponent } from "../../../data/actor-component";
 import { SelectableComponent } from "../../../entity/components/selectable-component";
 import { Subscription } from "rxjs";
-import { getGameObjectRenderedTransform } from "../../../data/game-object-helper";
+import {
+  getGameObjectCurrentTile,
+  getGameObjectLogicalTransform,
+  getGameObjectRenderedTransform
+} from "../../../data/game-object-helper";
 import { SharedActorActionsRallyPointSound } from "../../../sfx/shared-actor-actions-sfx";
 import { getSceneService } from "../../../world/services/scene-component-helpers";
 import { AudioService } from "../../../world/services/audio.service";
 import { IdComponent } from "../../../entity/components/id-component";
 import { ActorIndexSystem } from "../../../world/services/ActorIndexSystem";
+import { ActorTranslateComponent } from "../../../entity/components/movement/actor-translate-component";
+import { HealthComponent } from "../../../entity/components/combat/components/health-component";
+import { ResourceSourceComponent } from "../../../entity/components/resource/resource-source-component";
+import { OwnerComponent } from "../../../entity/components/owner-component";
 import GameObject = Phaser.GameObjects.GameObject;
 
 export default class RallyPoint extends Phaser.GameObjects.Image {
@@ -43,6 +51,9 @@ export default class RallyPoint extends Phaser.GameObjects.Image {
   public actor?: GameObject = undefined;
 
   private selectionChangedSubscription?: Subscription;
+  private ownerMovedSubscription?: Subscription;
+  private targetMovedSubscription?: Subscription;
+  private targetDepletedSubscription?: Subscription;
   private selectionComponent: SelectableComponent | undefined;
   private audioService?: AudioService;
 
@@ -56,13 +67,16 @@ export default class RallyPoint extends Phaser.GameObjects.Image {
     this.setDepth(this.drawDepth);
     this.lineGraphics.setDepth(this.drawDepth);
 
-    this.selectionComponent = getActorComponent(this.owner, SelectableComponent);
+    this.selectionComponent = getActorComponent(owner, SelectableComponent);
     if (this.selectionComponent) {
       this.selectionChangedSubscription = this.selectionComponent.selectionChanged.subscribe(() => {
         this.handleVisibility();
       });
     }
-    this.audioService = getSceneService(this.owner.scene, AudioService);
+    this.ownerMovedSubscription = getActorComponent(owner, ActorTranslateComponent)?.actorMovedLogicalPosition.subscribe(
+      () => this.drawLine()
+    );
+    this.audioService = getSceneService(owner.scene, AudioService);
   }
 
   private handleVisibility() {
@@ -87,6 +101,7 @@ export default class RallyPoint extends Phaser.GameObjects.Image {
 
   /* END-USER-CODE */
   setLocation(tileVec3: Vector3Simple, worldVec3: Vector3Simple) {
+    this.clearActorTargetSubscriptions();
     this.tileVec3 = tileVec3;
     this.worldVec3 = worldVec3;
     this.actor = undefined;
@@ -98,17 +113,30 @@ export default class RallyPoint extends Phaser.GameObjects.Image {
   }
 
   setActor(gameObject: Phaser.GameObjects.GameObject & Phaser.GameObjects.Components.Transform) {
+    this.clearActorTargetSubscriptions();
     this.actor = gameObject;
     this.tileVec3 = undefined;
     this.worldVec3 = undefined;
-    this.x = gameObject.x;
-    this.y = gameObject.y;
-    this.z = gameObject.z;
+    this.updatePositionFromActor();
+    this.subscribeToActorTarget(gameObject);
     this.handleVisibility();
+    this.playRallyPointSetSound();
   }
 
   isSet() {
     return this.tileVec3 || this.actor;
+  }
+
+  getTargetGameObject() {
+    return this.actor;
+  }
+
+  getTargetTileVec3() {
+    if (this.tileVec3) return this.tileVec3;
+    if (!this.actor) return undefined;
+    const tile = getGameObjectCurrentTile(this.actor);
+    if (!tile) return undefined;
+    return { x: tile.x, y: tile.y, z: 0 } satisfies Vector3Simple;
   }
 
   /**
@@ -173,19 +201,66 @@ export default class RallyPoint extends Phaser.GameObjects.Image {
       const actor = actorIndex?.getActorById(data.actorId);
       if (actor) {
         this.setActor(actor as any);
+      } else {
+        this.reset();
       }
     } else {
-      this.tileVec3 = undefined;
-      this.worldVec3 = undefined;
-      this.actor = undefined;
-      this.visible = false;
-      this.lineGraphics?.setVisible(false);
+      this.reset();
     }
   }
 
+  reset() {
+    this.clearActorTargetSubscriptions();
+    this.tileVec3 = undefined;
+    this.worldVec3 = undefined;
+    this.actor = undefined;
+    this.visible = false;
+    this.lineGraphics?.clear();
+    this.lineGraphics?.setVisible(false);
+  }
+
+  private subscribeToActorTarget(gameObject: Phaser.GameObjects.GameObject) {
+    this.targetMovedSubscription = getActorComponent(gameObject, ActorTranslateComponent)?.actorMovedLogicalPosition.subscribe(
+      () => {
+        this.updatePositionFromActor();
+        this.handleVisibility();
+      }
+    );
+    this.targetDepletedSubscription = getActorComponent(gameObject, ResourceSourceComponent)?.onDepleted.subscribe(() =>
+      this.reset()
+    );
+    gameObject.once(Phaser.GameObjects.Events.DESTROY, this.reset, this);
+    gameObject.once(HealthComponent.KilledEvent, this.reset, this);
+    gameObject.once(OwnerComponent.OwnerChangedEvent, this.reset, this);
+  }
+
+  private updatePositionFromActor() {
+    if (!this.actor) return;
+    const renderedTransform = getGameObjectRenderedTransform(this.actor);
+    const logicalTransform = getGameObjectLogicalTransform(this.actor);
+    if (!renderedTransform) return;
+    this.x = renderedTransform.x;
+    this.y = renderedTransform.y;
+    this.z = logicalTransform?.z ?? 0;
+  }
+
+  private clearActorTargetSubscriptions() {
+    if (this.actor) {
+      this.actor.off(Phaser.GameObjects.Events.DESTROY, this.reset, this);
+      this.actor.off(HealthComponent.KilledEvent, this.reset, this);
+      this.actor.off(OwnerComponent.OwnerChangedEvent, this.reset, this);
+    }
+    this.targetMovedSubscription?.unsubscribe();
+    this.targetMovedSubscription = undefined;
+    this.targetDepletedSubscription?.unsubscribe();
+    this.targetDepletedSubscription = undefined;
+  }
+
   override destroy(fromScene?: boolean) {
+    this.clearActorTargetSubscriptions();
     super.destroy(fromScene);
     this.selectionChangedSubscription?.unsubscribe();
+    this.ownerMovedSubscription?.unsubscribe();
     this.lineGraphics?.destroy();
   }
 }


### PR DESCRIPTION
## Summary
- Allow production building rally points to target actors through the existing command bus flow.
- Execute spawned unit rally behavior through the normal ActionSystem resolution path.
- Make actor rally markers follow their target and reset on destroy, kill, depletion, or owner changes.