### PR TITLE
feat: improve custom game discoverability (#636)

### DIFF
--- a/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.ts
+++ b/apps/client/src/app/probable-waffle/communicators/game-instance-client.service.ts
@@ -36,6 +36,7 @@ import {
 import { ServerHealthService } from "../../shared/services/server-health.service";
 import { SceneCommunicatorClientService } from "./scene-communicator-client.service";
 import { AuthService } from "../../auth/auth.service";
+import { CurrentUserProfileService } from "../../data-access/profile/current-user-profile.service";
 import { type GameInstanceClientServiceInterface } from "./game-instance-client.service.interface";
 import { Router } from "@angular/router";
 import { ProbableWaffleCommunicatorService } from "./probable-waffle-communicator.service";
@@ -62,6 +63,7 @@ export class GameInstanceClientService implements GameInstanceClientServiceInter
   currentPlayerNumber?: PlayerNumber;
 
   private readonly authService = inject(AuthService);
+  private readonly currentUserProfileService = inject(CurrentUserProfileService);
   private readonly httpClient = inject(HttpClient);
   private readonly serverHealthService = inject(ServerHealthService);
   private readonly sceneCommunicatorClientService = inject(SceneCommunicatorClientService);
@@ -491,7 +493,8 @@ export class GameInstanceClientService implements GameInstanceClientServiceInter
     const userId = this.authService.userId;
 
     await this.playerChanged("joinedFromNetwork", {
-      playerControllerData: { userId }
+      playerControllerData: { userId },
+      playerName: await this.getCurrentPlayerName()
     });
     console.log("joined game instance as player");
   }
@@ -502,7 +505,7 @@ export class GameInstanceClientService implements GameInstanceClientServiceInter
     const firstFreePlayerNumber = GameSetupHelpers.getFirstFreePlayerNumber(gameInstance.players);
     const firstFreePosition = GameSetupHelpers.getFirstFreePosition(gameInstance.players);
     const playerDefinition = {
-      player: createPlayerLobbyDefinition(firstFreePlayerNumber, firstFreePosition),
+      player: createPlayerLobbyDefinition(firstFreePlayerNumber, firstFreePosition, await this.getCurrentPlayerName()),
       playerType: ProbableWafflePlayerType.Human
     } satisfies PositionPlayerDefinition;
 
@@ -656,8 +659,21 @@ export class GameInstanceClientService implements GameInstanceClientServiceInter
     });
   }
 
+  private async getCurrentPlayerName(): Promise<string> {
+    try {
+      const profile = await this.currentUserProfileService.getCurrentUserProfile();
+      return profile?.displayName || this.authService.fullName || "Player";
+    } catch {
+      // A profile refresh must not prevent an authenticated player from joining a lobby.
+      return this.authService.fullName || "Player";
+    }
+  }
+
   async addSelfAsSpectator(): Promise<void> {
-    await this.spectatorChanged("joined", { userId: this.authService.userId! });
+    await this.spectatorChanged("joined", {
+      userId: this.authService.userId!,
+      displayName: await this.getCurrentPlayerName()
+    });
   }
 
   async getGameFoundListener(): Promise<Observable<ProbableWaffleGameFoundEvent>> {

--- a/apps/client/src/app/probable-waffle/gui/lobby/player-definition/player-definition.component.html
+++ b/apps/client/src/app/probable-waffle/gui/lobby/player-definition/player-definition.component.html
@@ -129,14 +129,23 @@
       }
     </div>
 
-    <div class="player-actions-container">
-      @if (allowOpenSlotForMp && !allFilled && isHost) {
-        <button (click)="openMpSlot()" class="btn btn-primary" type="button">Open MP Slot</button>
-      }
-      @if (!allFilled && isHost) {
-        <button (click)="addAiPlayer()" class="btn btn-primary" type="button">Add AI Player</button>
-      }
-    </div>
+    @if (!allFilled && isHost) {
+      <div class="add-player-card">
+        <div class="add-player-title">Add a player</div>
+        <div class="add-player-options">
+          @if (allowOpenSlotForMp) {
+            <button (click)="openMpSlot()" class="add-player-option" type="button">
+              <span>Open player space</span>
+              <small>Make space for another person to join this lobby.</small>
+            </button>
+          }
+          <button (click)="addAiPlayer()" class="add-player-option" type="button">
+            <span>Add A.I. player</span>
+            <small>Add a computer-controlled opponent.</small>
+          </button>
+        </div>
+      </div>
+    }
   </div>
 
   <fuzzy-waddle-modal #profileModal [modalConfig]="profileModalConfig">

--- a/apps/client/src/app/probable-waffle/gui/lobby/player-definition/player-definition.component.scss
+++ b/apps/client/src/app/probable-waffle/gui/lobby/player-definition/player-definition.component.scss
@@ -150,29 +150,69 @@
   }
 }
 
-.player-actions-container {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
+.add-player-card {
+  border: 2px dashed rgba(240, 196, 107, 0.54);
+  border-radius: 1rem;
+  overflow: hidden;
+  background-color: rgba(15, 18, 22, 0.62);
   margin-top: 1rem;
 
-  .btn {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    border-radius: $app-border-radius;
-    padding: 0.5rem 1rem;
-    font-weight: 500;
-    font-family: "Rajdhani", sans-serif;
-    transition: all 0.2s ease;
+  .add-player-title {
+    padding: 0.75rem 1rem;
+    color: #f0c46b;
+    font-family: "Cinzel", serif;
+    background-color: rgba(240, 196, 107, 0.08);
+  }
 
-    i {
-      font-size: 0.9rem;
+  .add-player-options {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+
+    @media (max-width: 576px) {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .add-player-option {
+    display: flex;
+    min-height: 9rem;
+    padding: 1.25rem;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.5rem;
+    border: 0;
+    border-right: 1px solid rgba(111, 85, 52, 0.45);
+    background: transparent;
+    color: #f5ecd9;
+    text-align: left;
+    transition: background-color 0.2s ease;
+
+    &:last-child {
+      border-right: 0;
     }
 
-    &:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 10px 18px rgba(0, 0, 0, 0.18);
+    @media (max-width: 576px) {
+      border-right: 0;
+      border-bottom: 1px solid rgba(111, 85, 52, 0.45);
+
+      &:last-child {
+        border-bottom: 0;
+      }
+    }
+
+    &:hover,
+    &:focus-visible {
+      background-color: rgba(240, 196, 107, 0.12);
+    }
+
+    span {
+      color: #f0c46b;
+      font-size: 1.1rem;
+      font-weight: 600;
+    }
+
+    small {
+      color: #c8b89b;
     }
   }
 }

--- a/apps/client/src/app/probable-waffle/gui/lobby/player-definition/player-definition.component.ts
+++ b/apps/client/src/app/probable-waffle/gui/lobby/player-definition/player-definition.component.ts
@@ -192,10 +192,8 @@ export class PlayerDefinitionComponent {
 
   getPlayerName(player: ProbableWafflePlayer) {
     const playerNumber = player.playerNumber!;
-    const isCurrentPlayer = this.getPlayerIsCurrentPlayer(player);
-    // noinspection UnnecessaryLocalVariableJS
-    const name = isCurrentPlayer ? "You" : `Player ${playerNumber}`;
-    return name;
+    const name = this.definition(player).player.playerName ?? `Player ${playerNumber}`;
+    return this.getPlayerIsCurrentPlayer(player) ? `${name} (You)` : name;
   }
 
   protected canViewProfile(player: ProbableWafflePlayer): boolean {

--- a/apps/client/src/app/probable-waffle/gui/lobby/spectators-grid/spectators-grid.component.html
+++ b/apps/client/src/app/probable-waffle/gui/lobby/spectators-grid/spectators-grid.component.html
@@ -1,10 +1,10 @@
 @if (gameInstanceClientService.gameInstance?.spectators?.length) {
-  <div class="card-container">
+  <div class="card-container spectators-container">
     <div class="general-title">Spectators</div>
     <div class="spectators">
       @for (spectator of gameInstanceClientService.gameInstance!.spectators; track spectator; let idx = $index) {
         <div class="spectator">
-          <div class="spectator-name">{{ "Spectator " + (idx + 1) }}</div>
+          <div class="spectator-name">{{ spectator.data.displayName ?? "Spectator " + (idx + 1) }}</div>
         </div>
       }
     </div>

--- a/apps/client/src/app/probable-waffle/gui/lobby/spectators-grid/spectators-grid.component.scss
+++ b/apps/client/src/app/probable-waffle/gui/lobby/spectators-grid/spectators-grid.component.scss
@@ -1,0 +1,3 @@
+.spectators-container {
+  margin: 1rem 0 0 !important;
+}

--- a/apps/client/src/app/probable-waffle/gui/online/lobbies/lobbies.component.html
+++ b/apps/client/src/app/probable-waffle/gui/online/lobbies/lobbies.component.html
@@ -1,5 +1,5 @@
 <div class="lobbies">
-  <div class="lobbies-tooltip">Browse currently open game lobbies to join or spectate</div>
+  <div class="lobbies-tooltip">Browse currently open game lobbies to join or spectate.</div>
 
   @if (getRoomsToJoin.length === 0) {
     <div class="text-center">No open lobbies</div>
@@ -7,6 +7,10 @@
       <button (click)="navigateToCreateLobby()" class="btn btn-primary" type="button">Create lobby</button>
     </div>
   } @else {
+    <div class="selection-help">
+      <div class="text-primary">Choose a lobby</div>
+      <div>Select a row to view its map, players, and join options.</div>
+    </div>
     <div class="d-flex">
       <div>
         <div>
@@ -27,7 +31,17 @@
           </thead>
           <tbody>
             @for (room of getRoomsToJoin; track room) {
-              <tr (click)="select(room)" class="cursor-pointer {{ room === selectedRoom ? 'selected-row' : '' }}">
+              <tr
+                (click)="select(room)"
+                (keydown.enter)="selectWithKeyboard($event, room)"
+                (keydown.space)="selectWithKeyboard($event, room)"
+                [attr.aria-selected]="room === selectedRoom"
+                [attr.title]="'Select ' + room.gameInstanceMetadataData.name + ' to view details'"
+                [class.selected-row]="room === selectedRoom"
+                class="cursor-pointer"
+                role="button"
+                tabindex="0"
+              >
                 <td>{{ room.gameInstanceMetadataData.name }}</td>
                 <td>
                   @if (room.gameModeData && mapInfoOfMap(room.gameModeData.map)) {
@@ -49,15 +63,26 @@
         </table>
       </div>
       @if (selectedRoom) {
-        <div class="card-container">
-          <div>
-            <img alt="map preview" [src]="mapInfo!.presentation.imagePath" />
-            <div style="font-size: 0.8em">{{ mapInfo!.presentation.description }}</div>
+        <div class="card-container lobby-details">
+          <div class="map-details">
+            @if (mapInfo; as selectedMap) {
+              <img [alt]="selectedMap.name + ' map preview'" [src]="selectedMap.presentation.imagePath" />
+              <div class="map-description">{{ selectedMap.presentation.description }}</div>
+            } @else {
+              <div class="empty-state">
+                <div class="text-primary">Map not selected yet</div>
+                <div>The host needs to choose a map before this lobby can start.</div>
+              </div>
+            }
           </div>
           <div>
             <div class="text-primary">Joined players</div>
-            @for (player of ProbableWaffleRoomHelper.getActivatedPlayersInRoom(selectedRoom); track player) {
-              <div>{{ player.controllerData.playerDefinition!.player.playerName }}</div>
+            @if (selectedRoomPlayers.length) {
+              @for (player of selectedRoomPlayers; track player) {
+                <div>{{ player.controllerData.playerDefinition!.player.playerName }}</div>
+              }
+            } @else {
+              <div class="empty-state">No players have joined yet.</div>
             }
           </div>
           @if (selectedRoom.spectators.length) {
@@ -70,18 +95,28 @@
       }
     </div>
 
-    <div>
-      <button (click)="addSelfAsPlayer()" [disabled]="!canAddSelfAsPlayer()" class="btn btn-primary" type="button">
+    <div class="lobby-actions">
+      <button
+        (click)="addSelfAsPlayer()"
+        [attr.aria-disabled]="!canAddSelfAsPlayer()"
+        [class.join-unavailable]="!canAddSelfAsPlayer()"
+        [title]="joinActionMessage"
+        class="btn btn-primary"
+        type="button"
+      >
         Join
       </button>
       <button
         (click)="addSelfAsSpectator()"
         [disabled]="!canAddSelfAsSpectator()"
-        class="ms-2 btn btn-primary"
+        class="btn btn-primary"
         type="button"
       >
         Spectate
       </button>
+      @if (!canAddSelfAsPlayer()) {
+        <div class="join-help">{{ joinActionMessage }}</div>
+      }
     </div>
   }
 </div>

--- a/apps/client/src/app/probable-waffle/gui/online/lobbies/lobbies.component.scss
+++ b/apps/client/src/app/probable-waffle/gui/online/lobbies/lobbies.component.scss
@@ -28,8 +28,18 @@
   color: #c8b89b;
 }
 
+.selection-help {
+  margin-bottom: 0.75rem;
+  color: #c8b89b;
+}
+
 .cursor-pointer {
   cursor: pointer;
+}
+
+tr.cursor-pointer:focus-visible td {
+  outline: 2px solid rgba(240, 196, 107, 0.9);
+  outline-offset: -2px;
 }
 
 .card-container {
@@ -49,6 +59,45 @@
   @media (max-width: 768px) {
     margin-top: 0;
   }
+}
+
+.lobby-details {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  .map-details {
+    text-align: center;
+  }
+
+  .map-description {
+    margin-top: 0.5rem;
+    font-size: 0.8em;
+    text-align: left;
+  }
+}
+
+.empty-state {
+  color: #c8b89b;
+  font-size: 0.9rem;
+}
+
+.join-unavailable {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.lobby-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.join-help {
+  flex-basis: 100%;
+  color: #c8b89b;
+  font-size: 0.85rem;
 }
 
 table {

--- a/apps/client/src/app/probable-waffle/gui/online/lobbies/lobbies.component.ts
+++ b/apps/client/src/app/probable-waffle/gui/online/lobbies/lobbies.component.ts
@@ -15,6 +15,7 @@ import { GameInstanceClientService } from "../../../communicators/game-instance-
 import { faFilter } from "@fortawesome/free-solid-svg-icons";
 import { FaIconComponent } from "@fortawesome/angular-fontawesome";
 import { MapFilterComponent } from "./map-filter/map-filter.component";
+import { ToastService } from "../../../../shared/services/toast.service";
 
 @Component({
   selector: "probable-waffle-lobbies",
@@ -29,6 +30,7 @@ export class LobbiesComponent implements OnInit, OnDestroy {
   protected selectedRoom?: ProbableWaffleRoom;
   private readonly roomsService = inject(RoomsService);
   private readonly gameInstanceClientService = inject(GameInstanceClientService);
+  private readonly toastService = inject(ToastService);
   readonly requestNavigateToHostLobby = output<void>();
 
   async ngOnInit(): Promise<void> {
@@ -49,11 +51,26 @@ export class LobbiesComponent implements OnInit, OnDestroy {
     );
   }
 
+  protected get joinActionMessage(): string {
+    if (!this.selectedRoom) return "Select a lobby to see how you can join it.";
+    if (this.selectedRoom.gameInstanceMetadataData.sessionState !== GameSessionState.NotStarted) {
+      return "This game has already started. You can still join it as a spectator.";
+    }
+    if (!this.selectedRoom.players.some(this.isNetworkOpenPlayer)) {
+      return "No multiplayer slots are open in this lobby. Ask the host to open a player slot.";
+    }
+    return "Join this lobby as a player.";
+  }
+
   protected canAddSelfAsSpectator(): boolean {
     return !!this.selectedRoom && this.selectedRoom.gameInstanceMetadataData.sessionState !== GameSessionState.Stopped;
   }
 
   protected async addSelfAsPlayer() {
+    if (!this.canAddSelfAsPlayer()) {
+      this.toastService.showWarning("Cannot join as player", this.joinActionMessage);
+      return;
+    }
     if (!this.selectedRoom?.gameInstanceMetadataData?.gameInstanceId) return;
     await this.gameInstanceClientService.joinGameInstanceAsPlayer(
       this.selectedRoom.gameInstanceMetadataData.gameInstanceId
@@ -71,6 +88,11 @@ export class LobbiesComponent implements OnInit, OnDestroy {
 
   protected select(room: ProbableWaffleRoom) {
     this.selectedRoom = room;
+  }
+
+  protected selectWithKeyboard(event: Event, room: ProbableWaffleRoom): void {
+    event.preventDefault();
+    this.select(room);
   }
 
   protected toggleFilterPopup(): void {
@@ -106,4 +128,11 @@ export class LobbiesComponent implements OnInit, OnDestroy {
           room.gameInstanceMetadataData?.type === ProbableWaffleGameInstanceType.SelfHosted
       );
   }
+
+  protected get selectedRoomPlayers() {
+    return this.selectedRoom ? ProbableWaffleRoomHelper.getActivatedPlayersInRoom(this.selectedRoom) : [];
+  }
+
+  private readonly isNetworkOpenPlayer = (player: ProbableWaffleRoom["players"][number]): boolean =>
+    player.controllerData.playerDefinition?.playerType === ProbableWafflePlayerType.NetworkOpen;
 }

--- a/apps/client/src/app/probable-waffle/gui/online/online.component.html
+++ b/apps/client/src/app/probable-waffle/gui/online/online.component.html
@@ -25,9 +25,13 @@
 
       @if (selectedMode === "custom") {
         <div class="custom-game-container">
+          <div class="custom-game-intro">
+            <h2>Custom multiplayer</h2>
+            <p>Join an available lobby, or create one and invite another player.</p>
+          </div>
           <ul class="nav-tabs">
-            <li (click)="selectTab('join')"><a [class.active]="selectedTab === 'join'">Join</a></li>
-            <li (click)="selectTab('host')"><a [class.active]="selectedTab === 'host'">Host</a></li>
+            <li (click)="selectTab('join')"><a [class.active]="selectedTab === 'join'">Join a game</a></li>
+            <li (click)="selectTab('host')"><a [class.active]="selectedTab === 'host'">Create a game</a></li>
           </ul>
           <div class="tab-content">
             @switch (selectedTab) {

--- a/apps/client/src/app/probable-waffle/gui/online/online.component.scss
+++ b/apps/client/src/app/probable-waffle/gui/online/online.component.scss
@@ -134,3 +134,20 @@
     }
   }
 }
+
+.custom-game-intro {
+  margin: 0.25rem 0 1.25rem;
+  text-align: center;
+
+  h2 {
+    margin-bottom: 0.35rem;
+    color: #f0c46b;
+    font-family: "Cinzel", serif;
+    font-size: 1.35rem;
+  }
+
+  p {
+    margin: 0;
+    color: #c8b89b;
+  }
+}

--- a/libs/api-interfaces/src/lib/communicators/probable-waffle/communicators.ts
+++ b/libs/api-interfaces/src/lib/communicators/probable-waffle/communicators.ts
@@ -100,6 +100,8 @@ export const ProbableWafflePlayerDataChangeProperties = {
 export type ProbableWafflePlayerDataChangeEventPayload = Partial<{
   // provide player number only when updating player
   playerNumber?: PlayerNumber;
+  // Sent when a human claims a lobby slot so every client can render the same player identity.
+  playerName?: string;
   playerStateData: Partial<ProbableWafflePlayerStateData>;
   playerControllerData: Partial<ProbableWafflePlayerControllerData>;
   data: Record<string, unknown>;

--- a/libs/api-interfaces/src/lib/communicators/probable-waffle/listeners.ts
+++ b/libs/api-interfaces/src/lib/communicators/probable-waffle/listeners.ts
@@ -110,6 +110,9 @@ export class ProbableWaffleListeners {
           firstNetworkOpenPlayer.playerController.data.userId = controllerData.userId;
           firstNetworkOpenPlayer.playerController.data.playerDefinition!.playerType = ProbableWafflePlayerType.Human;
           firstNetworkOpenPlayer.playerController.data.playerDefinition!.player.joined = true;
+          if (payload.data.playerName) {
+            firstNetworkOpenPlayer.playerController.data.playerDefinition!.player.playerName = payload.data.playerName;
+          }
           break;
         case "left":
           controllerData = payload.data.playerControllerData as ProbableWafflePlayerControllerData;

--- a/libs/api-interfaces/src/lib/game-instance/probable-waffle/spectator.ts
+++ b/libs/api-interfaces/src/lib/game-instance/probable-waffle/spectator.ts
@@ -7,4 +7,6 @@ export class ProbableWaffleSpectator extends BaseSpectator<ProbableWaffleSpectat
   }
 }
 
-export interface ProbableWaffleSpectatorData extends BaseSpectatorData {}
+export interface ProbableWaffleSpectatorData extends BaseSpectatorData {
+  displayName?: string;
+}


### PR DESCRIPTION
## Summary

- Clarify custom-game joining and lobby selection.

- Explain unavailable joins and improve lobby empty states.

- Show profile display names for players and spectators.

- Replace compact add-player actions with lobby player-space tiles.

## Reasons for Change

- Make multiplayer lobby creation and joining easier to understand.

